### PR TITLE
feat: Implement JSON-based enums for Telegram domain

### DIFF
--- a/src/main/java/com/roman3455/deplifybot/dto/telegram/api/enums/BotCommandScopeType.java
+++ b/src/main/java/com/roman3455/deplifybot/dto/telegram/api/enums/BotCommandScopeType.java
@@ -1,0 +1,24 @@
+package com.roman3455.deplifybot.dto.telegram.api.enums;
+
+import com.roman3455.deplifybot.util.enums.JsonEnum;
+
+public enum BotCommandScopeType implements JsonEnum {
+
+    DEFAULT("default"),
+    ALL_PRIVATE_CHATS("all_private_chats"),
+    ALL_GROUP_CHATS("all_group_chats"),
+    ALL_CHAT_ADMINISTRATORS("all_chat_administrators"),
+    CHAT("chat");
+
+    private final String value;
+
+    BotCommandScopeType(final String value) {
+        this.value = value;
+    }
+
+    @Override
+    public String getValue() {
+        return value;
+    }
+
+}

--- a/src/main/java/com/roman3455/deplifybot/dto/telegram/api/enums/UpdateType.java
+++ b/src/main/java/com/roman3455/deplifybot/dto/telegram/api/enums/UpdateType.java
@@ -1,0 +1,23 @@
+package com.roman3455.deplifybot.dto.telegram.api.enums;
+
+import com.roman3455.deplifybot.util.enums.JsonEnum;
+
+public enum UpdateType implements JsonEnum {
+
+    MESSAGE("message"),
+    EDITED_MESSAGE("edited_message"),
+    CALLBACK_QUERY("callback_query"),
+    MY_CHAT_MEMBER("my_chat_member");
+
+    private final String value;
+
+    UpdateType(final String value) {
+        this.value = value;
+    }
+
+    @Override
+    public String getValue() {
+        return value;
+    }
+
+}


### PR DESCRIPTION
- BotCommandScopeType:
  - default
  - all_private_chats
  - all_group_chats
  - all_chat_administrators
  - chat
- UpdateType:
  - message
  - edited_message
  - callback_query
  - my_chat_member

Closes: issue-0014