### PR TITLE
feat: implement Telegram API error handling and response decoding

### DIFF
--- a/src/main/java/com/roman3455/deplifybot/configuration/TelegramFeignConfig.java
+++ b/src/main/java/com/roman3455/deplifybot/configuration/TelegramFeignConfig.java
@@ -1,7 +1,29 @@
 package com.roman3455.deplifybot.configuration;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.roman3455.deplifybot.exception.TelegramErrorDecoder;
+import feign.codec.ErrorDecoder;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+/**
+ * Customizing Feign behavior when interacting with the Telegram API.
+ * <p>Registers a custom {@link ErrorDecoder} that maps Telegram HTTP error responses to structured
+ * {@link com.roman3455.deplifybot.exception.telegram.TelegramApiException} types via {@link TelegramErrorDecoder}.
+ * This ensures consistent error handling across all Telegram Feign clients.
+ */
 @Configuration
 public class TelegramFeignConfig {
+
+    /**
+     * Provides a {@link TelegramErrorDecoder} bean for Feign.
+     *
+     * @param objectMapper the shared {@link ObjectMapper} used to parse Telegram API error responses.
+     * @return a configured {@link ErrorDecoder} instance.
+     */
+    @Bean
+    ErrorDecoder telegramErrorDecoder(final ObjectMapper objectMapper) {
+        return new TelegramErrorDecoder(objectMapper);
+    }
+
 }

--- a/src/main/java/com/roman3455/deplifybot/dto/telegram/api/response/ResponseBody.java
+++ b/src/main/java/com/roman3455/deplifybot/dto/telegram/api/response/ResponseBody.java
@@ -1,0 +1,56 @@
+package com.roman3455.deplifybot.dto.telegram.api.response;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * DTO represents a generic API response wrapper returned by Telegram Bot API or similar services.
+ *
+ * <p>The {@code ResponseBody} contains both successful and error responses.</p>
+ *
+ * @param ok          required. Indicates whether the request was successful.
+ * @param result      optional. The actual result object returned by the API if {@code ok} is {@code true}.
+ * @param errorCode   optional. The error code returned by the API if {@code ok} is {@code false}.
+ * @param description optional. A human-readable description of the error.
+ * @param parameters  optional additional response parameters such as retry information or migration targets.
+ */
+public record ResponseBody<T>(
+
+        boolean ok,
+        @Nullable T result,
+        @Nullable Integer errorCode,
+        @Nullable String description,
+        @Nullable ResponseParameters parameters
+
+) {
+
+    /**
+     * DTO represents optional extra response parameters returned by the API.
+     *
+     * <p>Typically present for specific error conditions.</p>
+     *
+     * @param migrateToChatId optional. New chat ID to migrate to, if applicable.
+     * @param retryAfter      optional. Number of seconds to wait before retrying, if applicable.
+     */
+    public record ResponseParameters(
+
+            @Nullable Long migrateToChatId,
+            @Nullable Integer retryAfter
+
+    ) {
+    }
+
+    /**
+     * @return {@code true} if this response contains error information.
+     */
+    public boolean isError() {
+        return !ok;
+    }
+
+    /**
+     * @return {@code true} if {@link #parameters} is not {@code null}
+     */
+    public boolean hasParameters() {
+        return parameters != null;
+    }
+
+}

--- a/src/main/java/com/roman3455/deplifybot/exception/TelegramErrorDecoder.java
+++ b/src/main/java/com/roman3455/deplifybot/exception/TelegramErrorDecoder.java
@@ -1,0 +1,102 @@
+package com.roman3455.deplifybot.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.roman3455.deplifybot.dto.telegram.api.response.ResponseBody;
+import com.roman3455.deplifybot.exception.telegram.TelegramBadRequestException;
+import com.roman3455.deplifybot.exception.telegram.TelegramForbiddenException;
+import com.roman3455.deplifybot.exception.telegram.TelegramNotAcceptableException;
+import com.roman3455.deplifybot.exception.telegram.TelegramNotFoundException;
+import com.roman3455.deplifybot.exception.telegram.TelegramPayloadTooLargeException;
+import com.roman3455.deplifybot.exception.telegram.TelegramServerException;
+import com.roman3455.deplifybot.exception.telegram.TelegramTooManyRequestsException;
+import com.roman3455.deplifybot.exception.telegram.TelegramUnauthorizedException;
+import feign.FeignException;
+import feign.Response;
+import feign.codec.ErrorDecoder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Optional;
+
+/**
+ * Feign {@link ErrorDecoder} implementation for handling errors returned by the Telegram Bot API.
+ *
+ * <p>This decoder reads the response body and converts HTTP error statuses into corresponding
+ * {@link com.roman3455.deplifybot.exception.telegram.TelegramApiException} types, providing a more
+ * expressive and structured error handling mechanism.</p>
+ *
+ * <p>Supported HTTP status mappings:</p>
+ * <ul>
+ *   <li>400 → {@link TelegramBadRequestException}</li>
+ *   <li>401 → {@link TelegramUnauthorizedException}</li>
+ *   <li>403 → {@link TelegramForbiddenException}</li>
+ *   <li>404 → {@link TelegramNotFoundException}</li>
+ *   <li>406 → {@link TelegramNotAcceptableException}</li>
+ *   <li>413 → {@link TelegramPayloadTooLargeException}</li>
+ *   <li>420, 429 → {@link TelegramTooManyRequestsException}</li>
+ *   <li>500, 502, 503, 504 → {@link TelegramServerException}</li>
+ * </ul>
+ * <p>For all other status codes, a generic {@link RuntimeException} is thrown.</p>
+ */
+public record TelegramErrorDecoder(ObjectMapper mapper) implements ErrorDecoder {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TelegramErrorDecoder.class);
+
+    private static final int BAD_REQUEST = 400;
+    private static final int UNAUTHORIZED = 401;
+    private static final int FORBIDDEN = 403;
+    private static final int NOT_FOUND = 404;
+    private static final int NOT_ACCEPTABLE = 406;
+    private static final int PAYLOAD_TOO_LARGE = 413;
+    private static final int ENHANCE_YOUR_CALM = 420;
+    private static final int TOO_MANY_REQUESTS = 429;
+    private static final int INTERNAL_SERVER_ERROR = 500;
+    private static final int BAD_GATEWAY = 502;
+    private static final int SERVICE_UNAVAILABLE = 503;
+    private static final int GATEWAY_TIMEOUT = 504;
+
+    /**
+     * Decodes a failed Feign client call to a Telegram API into a structured exception.
+     *
+     * @param methodKey the Feign method key that caused the error.
+     * @param response  the HTTP response returned by Telegram.
+     * @return a specific {@code TelegramApiException} or a {@code RuntimeException} if the error is unexpected.
+     */
+    @Override
+    public Exception decode(final String methodKey, final Response response) {
+        if (response.body() == null) {
+            return new RuntimeException("Telegram returned empty error body, status: " + response.status());
+        }
+        try (InputStream inputStream = response.body().asInputStream()) {
+            ResponseBody<?> exception = mapper.readValue(inputStream, ResponseBody.class);
+            LOG.warn(
+                    "Feign method [{}] failed. Telegram API error [{}]: {}",
+                    methodKey, response.status(), exception.description()
+            );
+            return switch (response.status()) {
+                case BAD_REQUEST -> new TelegramBadRequestException(exception.description());
+                case UNAUTHORIZED -> new TelegramUnauthorizedException(exception.description());
+                case FORBIDDEN -> new TelegramForbiddenException(exception.description());
+                case NOT_FOUND -> new TelegramNotFoundException(exception.description());
+                case NOT_ACCEPTABLE -> new TelegramNotAcceptableException(exception.description());
+                case PAYLOAD_TOO_LARGE -> new TelegramPayloadTooLargeException(exception.description());
+                case ENHANCE_YOUR_CALM, TOO_MANY_REQUESTS -> {
+                    long retryAfter = Optional.ofNullable(exception.parameters())
+                            .map(ResponseBody.ResponseParameters::retryAfter)
+                            .orElse(0);
+                    yield new TelegramTooManyRequestsException(exception.description(), retryAfter);
+                }
+                case INTERNAL_SERVER_ERROR, BAD_GATEWAY, SERVICE_UNAVAILABLE, GATEWAY_TIMEOUT ->
+                        new TelegramServerException(exception.description());
+                default -> new RuntimeException("Unexpected Telegram exception (" + response.status() + "): "
+                        + exception.description());
+            };
+        } catch (IOException e) {
+            LOG.error("Failed to parse Telegram error response", e);
+            return FeignException.errorStatus(methodKey, response);
+        }
+    }
+
+}

--- a/src/main/java/com/roman3455/deplifybot/exception/telegram/TelegramApiException.java
+++ b/src/main/java/com/roman3455/deplifybot/exception/telegram/TelegramApiException.java
@@ -1,0 +1,14 @@
+package com.roman3455.deplifybot.exception.telegram;
+
+/**
+ * Base class for all Telegram API related exceptions.
+ *
+ * <p>Thrown when the Telegram Bot API returns an error response.</p>
+ */
+public abstract class TelegramApiException extends RuntimeException {
+
+    public TelegramApiException(final String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/com/roman3455/deplifybot/exception/telegram/TelegramBadRequestException.java
+++ b/src/main/java/com/roman3455/deplifybot/exception/telegram/TelegramBadRequestException.java
@@ -1,0 +1,12 @@
+package com.roman3455.deplifybot.exception.telegram;
+
+/**
+ * Thrown when the Telegram API responds with HTTP 400 (Bad Request).
+ */
+public class TelegramBadRequestException extends TelegramApiException {
+
+    public TelegramBadRequestException(final String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/com/roman3455/deplifybot/exception/telegram/TelegramForbiddenException.java
+++ b/src/main/java/com/roman3455/deplifybot/exception/telegram/TelegramForbiddenException.java
@@ -1,0 +1,12 @@
+package com.roman3455.deplifybot.exception.telegram;
+
+/**
+ * Thrown when the Telegram API responds with HTTP 403 (Forbidden).
+ */
+public class TelegramForbiddenException extends TelegramApiException {
+
+    public TelegramForbiddenException(final String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/com/roman3455/deplifybot/exception/telegram/TelegramNotAcceptableException.java
+++ b/src/main/java/com/roman3455/deplifybot/exception/telegram/TelegramNotAcceptableException.java
@@ -1,0 +1,12 @@
+package com.roman3455.deplifybot.exception.telegram;
+
+/**
+ * Thrown when the Telegram API responds with HTTP 406 (Not Acceptable).
+ */
+public class TelegramNotAcceptableException extends TelegramApiException {
+
+    public TelegramNotAcceptableException(final String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/com/roman3455/deplifybot/exception/telegram/TelegramNotFoundException.java
+++ b/src/main/java/com/roman3455/deplifybot/exception/telegram/TelegramNotFoundException.java
@@ -1,0 +1,12 @@
+package com.roman3455.deplifybot.exception.telegram;
+
+/**
+ * Thrown when the Telegram API responds with HTTP 404 (Not Found).
+ */
+public class TelegramNotFoundException extends TelegramApiException {
+
+    public TelegramNotFoundException(final String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/com/roman3455/deplifybot/exception/telegram/TelegramPayloadTooLargeException.java
+++ b/src/main/java/com/roman3455/deplifybot/exception/telegram/TelegramPayloadTooLargeException.java
@@ -1,0 +1,12 @@
+package com.roman3455.deplifybot.exception.telegram;
+
+/**
+ * Thrown when the Telegram API responds with HTTP 413 (Payload Too Large).
+ */
+public class TelegramPayloadTooLargeException extends TelegramApiException {
+
+    public TelegramPayloadTooLargeException(final String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/com/roman3455/deplifybot/exception/telegram/TelegramServerException.java
+++ b/src/main/java/com/roman3455/deplifybot/exception/telegram/TelegramServerException.java
@@ -1,0 +1,13 @@
+package com.roman3455.deplifybot.exception.telegram;
+
+/**
+ * Thrown when the Telegram API responds with HTTP 500 (Internal Server Error)
+ * or other server-side error codes.
+ */
+public class TelegramServerException extends TelegramApiException {
+
+    public TelegramServerException(final String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/com/roman3455/deplifybot/exception/telegram/TelegramTooManyRequestsException.java
+++ b/src/main/java/com/roman3455/deplifybot/exception/telegram/TelegramTooManyRequestsException.java
@@ -1,0 +1,24 @@
+package com.roman3455.deplifybot.exception.telegram;
+
+/**
+ * Thrown when the Telegram API responds with HTTP 429 (Too Many Requests).
+ *
+ * <p>Contains a {@code retryAfter} value indicating how long to wait before retrying.</p>
+ */
+public class TelegramTooManyRequestsException extends TelegramApiException {
+
+    private final long retryAfter;
+
+    public TelegramTooManyRequestsException(final String message, final long retryAfter) {
+        super(message);
+        this.retryAfter = retryAfter;
+    }
+
+    /**
+     * @return number of seconds to wait before retrying the request
+     */
+    public long getRetryAfter() {
+        return retryAfter;
+    }
+
+}

--- a/src/main/java/com/roman3455/deplifybot/exception/telegram/TelegramUnauthorizedException.java
+++ b/src/main/java/com/roman3455/deplifybot/exception/telegram/TelegramUnauthorizedException.java
@@ -1,0 +1,12 @@
+package com.roman3455.deplifybot.exception.telegram;
+
+/**
+ * Thrown when the Telegram API responds with HTTP 401 (Unauthorized).
+ */
+public class TelegramUnauthorizedException extends TelegramApiException {
+
+    public TelegramUnauthorizedException(final String message) {
+        super(message);
+    }
+
+}

--- a/src/test/java/com/roman3455/deplifybot/ApplicationTest.java
+++ b/src/test/java/com/roman3455/deplifybot/ApplicationTest.java
@@ -1,6 +1,7 @@
 package com.roman3455.deplifybot;
 
 import com.roman3455.deplifybot.client.TelegramClient;
+import com.roman3455.deplifybot.configuration.TelegramFeignConfig;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -20,6 +21,9 @@ class ApplicationTest {
     @Autowired
     private TelegramClient telegramClient;
 
+    @Autowired
+    private TelegramFeignConfig telegramFeignConfig;
+
     @Test
     void contextLoads() {
         assertThat(applicationContext).isNotNull();
@@ -28,6 +32,11 @@ class ApplicationTest {
     @Test
     void  contextLoadsTelegramClient() {
         assertThat(telegramClient).isNotNull();
+    }
+
+    @Test
+    void  contextLoadsTelegramFeignConfig() {
+        assertThat(telegramFeignConfig).isNotNull();
     }
 
     @Test

--- a/src/test/java/com/roman3455/deplifybot/dto/telegram/api/response/ResponseBodyJsonTest.java
+++ b/src/test/java/com/roman3455/deplifybot/dto/telegram/api/response/ResponseBodyJsonTest.java
@@ -1,0 +1,118 @@
+package com.roman3455.deplifybot.dto.telegram.api.response;
+
+import com.roman3455.deplifybot.configuration.JacksonConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.json.JsonTest;
+import org.springframework.boot.test.json.JacksonTester;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.io.ClassPathResource;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
+
+@JsonTest
+@Import(JacksonConfiguration.class)
+@DisplayName("ResponseBody — JSON serialization & deserialization")
+class ResponseBodyJsonTest {
+
+    @Autowired
+    private JacksonTester<ResponseBody<?>> json;
+
+    private static final String SOURCE = "/fixture/telegram/response/response_body/";
+    private static final String SUCCESS = SOURCE + "response_body_success.json";
+    private static final String ERROR_429 = SOURCE + "response_body_error_429_with_retry.json";
+    private static final String ERROR_404 = SOURCE + "response_body_error_404_with_migrate.json";
+
+    private ResponseBody<Map<String, Object>> successPayload;
+    private ResponseBody<Map<String, Object>> error429Payload;
+    private ResponseBody<Map<String, Object>> error404Payload;
+
+    @BeforeEach
+    void setUp() {
+        successPayload = new ResponseBody<>(
+                true,
+                Map.of("message_id", 1, "text", "hello"),
+                null,
+                null,
+                null
+        );
+        final int tooManyRequests = 429;
+        error429Payload = new ResponseBody<>(
+                false,
+                null,
+                tooManyRequests,
+                "Too Many Requests: retry after 1",
+                new ResponseBody.ResponseParameters(null, 1)
+        );
+        final int badRequest = 400;
+        final long chatId = -1001987654321L;
+        error404Payload = new ResponseBody<>(
+                false,
+                null,
+                badRequest,
+                "Bad Request: group chat was upgraded to a supergroup chat",
+                new ResponseBody.ResponseParameters(chatId, null)
+        );
+    }
+
+    @Test
+    @DisplayName("Serializes success payload")
+    void serializeSuccessPayload() throws Exception {
+        var actual = json.write(successPayload);
+        then(actual).isNotNull();
+        then(actual).isEqualToJson(new ClassPathResource(SUCCESS));
+    }
+
+    @Test
+    @DisplayName("Deserializes success payload into populated fields")
+    void deserializeSuccessPayload() throws Exception {
+        var actual = json.readObject(SUCCESS);
+        then(actual).isNotNull();
+        then(actual).isEqualTo(successPayload);
+        assertThat(actual.isError()).isFalse();
+        assertThat(actual.hasParameters()).isFalse();
+    }
+
+    @Test
+    @DisplayName("Serializes error 429 payload with 'retryAfter' parameter")
+    void serializeError429Payload() throws Exception {
+        var actual = json.write(error429Payload);
+        then(actual).isNotNull();
+        then(actual).isEqualToJson(new ClassPathResource(ERROR_429));
+        then(actual).doesNotHaveJsonPath("$.errorCode");
+    }
+
+    @Test
+    @DisplayName("Deserializes error 429 payload into populated fields")
+    void deserializeError429Payload() throws Exception {
+        var actual = json.readObject(ERROR_429);
+        then(actual).isNotNull();
+        then(actual).isEqualTo(error429Payload);
+        assertThat(actual.isError()).isTrue();
+        assertThat(actual.hasParameters()).isTrue();
+    }
+
+    @Test
+    @DisplayName("Serializes error 404 payload with 'migrateToChatId' parameter")
+    void serializeError404Payload() throws Exception {
+        var actual = json.write(error404Payload);
+        then(actual).isNotNull();
+        then(actual).isEqualToJson(new ClassPathResource(ERROR_404));
+    }
+
+    @Test
+    @DisplayName("Deserializes error 404 payload into populated fields")
+    void deserializeError404Payload() throws Exception {
+        var actual = json.readObject(ERROR_404);
+        then(actual).isNotNull();
+        then(actual).isEqualTo(error404Payload);
+        assertThat(actual.isError()).isTrue();
+        assertThat(actual.hasParameters()).isTrue();
+    }
+
+}

--- a/src/test/resources/fixture/telegram/response/response_body/response_body_error_404_with_migrate.json
+++ b/src/test/resources/fixture/telegram/response/response_body/response_body_error_404_with_migrate.json
@@ -1,0 +1,8 @@
+{
+  "ok": false,
+  "error_code": 400,
+  "description": "Bad Request: group chat was upgraded to a supergroup chat",
+  "parameters": {
+    "migrate_to_chat_id": -1001987654321
+  }
+}

--- a/src/test/resources/fixture/telegram/response/response_body/response_body_error_429_with_retry.json
+++ b/src/test/resources/fixture/telegram/response/response_body/response_body_error_429_with_retry.json
@@ -1,0 +1,8 @@
+{
+  "ok": false,
+  "error_code": 429,
+  "description": "Too Many Requests: retry after 1",
+  "parameters": {
+    "retry_after": 1
+  }
+}

--- a/src/test/resources/fixture/telegram/response/response_body/response_body_success.json
+++ b/src/test/resources/fixture/telegram/response/response_body/response_body_success.json
@@ -1,0 +1,7 @@
+{
+  "ok": true,
+  "result": {
+    "message_id": 1,
+    "text": "hello"
+  }
+}


### PR DESCRIPTION
- add TelegramApiException (400, 401, 403, 404, 406, 413, 420, 429, 500, 502, 503, 504)
- add ResponseBody with tests and json fixture
- add ErrorDecoder into TelegramFeignConfig

Closes: issue-0021