### PR TITLE
feat(http): add TelegramClientService layer for outgoing API calls

### DIFF
--- a/src/main/java/com/roman3455/deplifybot/client/TelegramClient.java
+++ b/src/main/java/com/roman3455/deplifybot/client/TelegramClient.java
@@ -1,8 +1,66 @@
 package com.roman3455.deplifybot.client;
 
 import com.roman3455.deplifybot.configuration.TelegramFeignConfig;
+import com.roman3455.deplifybot.dto.telegram.api.request.BotDescriptionRequest;
+import com.roman3455.deplifybot.dto.telegram.api.request.BotShortDescriptionRequest;
+import com.roman3455.deplifybot.dto.telegram.api.request.SetMyCommandsRequest;
+import com.roman3455.deplifybot.dto.telegram.api.request.SetWebhookRequest;
+import com.roman3455.deplifybot.dto.telegram.api.response.ResponseBody;
+import jakarta.validation.Valid;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
+/**
+ * Feign client for interacting with the Telegram Bot API.
+ *
+ * <p>All methods require valid request DTOs that comply with Telegram Bot API constraints.
+ * If the request is invalid, a 4xx error may be returned from the Telegram side.</p>
+ *
+ * @see <a href="https://core.telegram.org/bots/api#available-methods">Telegram Bot API — Available methods</a>
+ */
 @FeignClient(name = "telegram", configuration = TelegramFeignConfig.class)
 public interface TelegramClient {
+
+    /**
+     * Sets the bot’s description shown in the chat with the bot.
+     *
+     * @param request the {@link BotDescriptionRequest} containing the description and optional language code.
+     * @return a {@link ResponseBody} with a boolean indicating whether the operation succeeded.
+     * @see <a href="https://core.telegram.org/bots/api#setmydescription">Telegram API — setMyDescription</a>
+     */
+    @PostMapping(value = "/setMyDescription", consumes = "application/json", produces = "application/json")
+    ResponseBody<Boolean> setMyDescription(@RequestBody @Valid BotDescriptionRequest request);
+
+    /**
+     * Sets the bot’s short description, which is displayed on the bot profile page and in the list of bots.
+     *
+     * @param request the {@link BotShortDescriptionRequest} containing the short description and optional
+     *                language code.
+     * @return a {@link ResponseBody} with a boolean indicating whether the operation succeeded
+     * @see <a href="https://core.telegram.org/bots/api#setmyshortdescription">Telegram API — setMyShortDescription</a>
+     */
+    @PostMapping(value = "/setMyShortDescription", consumes = "application/json", produces = "application/json")
+    ResponseBody<Boolean> setMyShortDescription(@RequestBody @Valid BotShortDescriptionRequest request);
+
+    /**
+     * Sets the list of bot commands. Commands are shown as a menu to users.
+     *
+     * @param request the {@link SetMyCommandsRequest} containing commands, scope, and optional language code.
+     * @return a {@link ResponseBody} with a boolean indicating whether the operation succeeded.
+     * @see <a href="https://core.telegram.org/bots/api#setmycommands">Telegram API — setMyCommands</a>
+     */
+    @PostMapping(value = "/setMyCommands", consumes = "application/json", produces = "application/json")
+    ResponseBody<Boolean> setMyCommands(@RequestBody @Valid SetMyCommandsRequest request);
+
+    /**
+     * Configures a webhook URL to receive incoming updates for the bot.
+     *
+     * @param request the {@link SetWebhookRequest} containing webhook configuration.
+     * @return a {@link ResponseBody} with a boolean indicating whether the operation succeeded.
+     * @see <a href="https://core.telegram.org/bots/api#setwebhook">Telegram API — setWebhook</a>
+     */
+    @PostMapping(value = "/setWebhook", consumes = "application/json", produces = "application/json")
+    ResponseBody<Boolean> setWebhook(@RequestBody @Valid SetWebhookRequest request);
+
 }

--- a/src/main/java/com/roman3455/deplifybot/service/telegram/TelegramClientService.java
+++ b/src/main/java/com/roman3455/deplifybot/service/telegram/TelegramClientService.java
@@ -1,0 +1,56 @@
+package com.roman3455.deplifybot.service.telegram;
+
+import com.roman3455.deplifybot.dto.telegram.api.request.BotDescriptionRequest;
+import com.roman3455.deplifybot.dto.telegram.api.request.BotShortDescriptionRequest;
+import com.roman3455.deplifybot.dto.telegram.api.request.SetMyCommandsRequest;
+import com.roman3455.deplifybot.dto.telegram.api.request.SetWebhookRequest;
+import com.roman3455.deplifybot.dto.telegram.api.response.ResponseBody;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Internal service interface for managing Telegram Bot configuration.
+ *
+ * <p>This service provides high-level operations for setting bot metadata
+ * (description, short description, commands, and webhook settings).
+ * It delegates actual HTTP requests to TelegramClient.</p>
+ *
+ * <p>All DTOs are validated before sending to the Telegram API.</p>
+ *
+ * @see com.roman3455.deplifybot.client.TelegramClient
+ */
+public interface TelegramClientService {
+
+    /**
+     * Updates the bot description.
+     *
+     * @param request the validated description request.
+     * @return response indicating success or failure.
+     */
+    ResponseBody<Boolean> setMyDescription(@Valid @NotNull BotDescriptionRequest request);
+
+    /**
+     * Updates the bot short description.
+     *
+     * @param request the validated short description request.
+     * @return response indicating success or failure.
+     */
+    ResponseBody<Boolean> setMyShortDescription(@Valid @NotNull BotShortDescriptionRequest request);
+
+    /**
+     * Updates the list of bot commands.
+     *
+     * @param request the validated commands request.
+     * @return response indicating success or failure.
+     */
+    ResponseBody<Boolean> setMyCommands(@Valid @NotNull SetMyCommandsRequest request);
+
+    /**
+     * Configures the bot webhook.
+     *
+     * @param request the validated webhook request.
+     * @return response indicating success or failure.
+     */
+    ResponseBody<Boolean> setWebhook(@Valid @NotNull SetWebhookRequest request);
+
+}

--- a/src/main/java/com/roman3455/deplifybot/service/telegram/impl/TelegramClientServiceImpl.java
+++ b/src/main/java/com/roman3455/deplifybot/service/telegram/impl/TelegramClientServiceImpl.java
@@ -1,0 +1,65 @@
+package com.roman3455.deplifybot.service.telegram.impl;
+
+import com.roman3455.deplifybot.client.TelegramClient;
+import com.roman3455.deplifybot.dto.telegram.api.request.BotDescriptionRequest;
+import com.roman3455.deplifybot.dto.telegram.api.request.BotShortDescriptionRequest;
+import com.roman3455.deplifybot.dto.telegram.api.request.SetMyCommandsRequest;
+import com.roman3455.deplifybot.dto.telegram.api.request.SetWebhookRequest;
+import com.roman3455.deplifybot.dto.telegram.api.response.ResponseBody;
+import com.roman3455.deplifybot.service.telegram.TelegramClientService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.stereotype.Service;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * Default implementation of {@link TelegramClientService} based on {@link TelegramClient}.
+ *
+ * <p>This service delegates actual HTTP communication to {@link TelegramClient}
+ * and applies basic validation on input DTOs.</p>
+ *
+ * @see TelegramClientService
+ */
+@Service
+@Validated
+public class TelegramClientServiceImpl implements TelegramClientService {
+
+    private final TelegramClient client;
+
+    public TelegramClientServiceImpl(final TelegramClient client) {
+        this.client = client;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ResponseBody<Boolean> setMyDescription(@Valid @NotNull final BotDescriptionRequest request) {
+        return client.setMyDescription(request);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ResponseBody<Boolean> setMyShortDescription(@Valid @NotNull final BotShortDescriptionRequest request) {
+        return client.setMyShortDescription(request);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ResponseBody<Boolean> setMyCommands(@Valid @NotNull final SetMyCommandsRequest request) {
+        return client.setMyCommands(request);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ResponseBody<Boolean> setWebhook(@Valid @NotNull final SetWebhookRequest request) {
+        return client.setWebhook(request);
+    }
+
+}

--- a/src/test/java/com/roman3455/deplifybot/service/telegram/TelegramClientServiceImplTest.java
+++ b/src/test/java/com/roman3455/deplifybot/service/telegram/TelegramClientServiceImplTest.java
@@ -1,0 +1,97 @@
+package com.roman3455.deplifybot.service.telegram;
+
+import com.roman3455.deplifybot.client.TelegramClient;
+import com.roman3455.deplifybot.dto.telegram.api.request.BotDescriptionRequest;
+import com.roman3455.deplifybot.dto.telegram.api.request.BotShortDescriptionRequest;
+import com.roman3455.deplifybot.dto.telegram.api.request.MyCommand;
+import com.roman3455.deplifybot.dto.telegram.api.request.SetMyCommandsRequest;
+import com.roman3455.deplifybot.dto.telegram.api.request.SetWebhookRequest;
+import com.roman3455.deplifybot.dto.telegram.api.response.ResponseBody;
+import com.roman3455.deplifybot.exception.telegram.TelegramTooManyRequestsException;
+import com.roman3455.deplifybot.service.telegram.impl.TelegramClientServiceImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("TelegramClientServiceImpl — delegation & exceptions tests")
+class TelegramClientServiceImplTest {
+
+    @Mock
+    private TelegramClient client;
+
+    @InjectMocks
+    private TelegramClientServiceImpl service;
+
+    @Test
+    @DisplayName("setMyDescription: delegates to Feign client and returns expected response")
+    void setMyDescriptionDelegatesToFeignClientAndReturnsExpectedResponse() {
+        var req = new BotDescriptionRequest("Test description", "en");
+        var expected = new ResponseBody<>(true, true, null, null, null);
+        when(client.setMyDescription(req)).thenReturn(expected);
+        var actual = service.setMyDescription(req);
+        assertThat(actual).isSameAs(expected);
+        verify(client).setMyDescription(req);
+        verifyNoMoreInteractions(client);
+    }
+
+    @Test
+    @DisplayName("setMyShortDescription: delegates to Feign client and returns expected response")
+    void setMyShortDescriptionDelegatesToClientAndReturnsResponse() {
+        var req = new BotShortDescriptionRequest("Test short description", "en");
+        var expected = new ResponseBody<>(true, true, null, null, null);
+        when(client.setMyShortDescription(req)).thenReturn(expected);
+        var actual = service.setMyShortDescription(req);
+        assertThat(actual).isSameAs(expected);
+        verify(client).setMyShortDescription(req);
+        verifyNoMoreInteractions(client);
+    }
+
+    @Test
+    @DisplayName("setMyCommands: delegates to Feign client and returns expected response")
+    void setMyCommandsDelegatesToClientAndReturnsResponse() {
+        var req = new SetMyCommandsRequest(List.of(new MyCommand("c", "d")), null, null);
+        var expected = new ResponseBody<>(true, true, null, null, null);
+        when(client.setMyCommands(req)).thenReturn(expected);
+        var actual = service.setMyCommands(req);
+        assertThat(actual).isSameAs(expected);
+        verify(client).setMyCommands(req);
+        verifyNoMoreInteractions(client);
+    }
+
+    @Test
+    @DisplayName("setWebhook: delegates to Feign client and returns expected response")
+    void setWebhookDelegatesToClientAndReturnsResponse() {
+        var req = new SetWebhookRequest("https://example.com/webhook", null, null, null, null);
+        var expected = new ResponseBody<>(true, true, null, null, null);
+        when(client.setWebhook(req)).thenReturn(expected);
+        var actual = service.setWebhook(req);
+        assertThat(actual).isSameAs(expected);
+        verify(client).setWebhook(req);
+        verifyNoMoreInteractions(client);
+    }
+
+    @Test
+    @DisplayName("setMyCommands: propagates TelegramTooManyRequestsException from Feign client")
+    void setMyCommandsPropagatesClientException() {
+        var req = new SetMyCommandsRequest(List.of(), null, null);
+        var err = new TelegramTooManyRequestsException("429", 1);
+        when(client.setMyCommands(req)).thenThrow(err);
+        assertThatThrownBy(() -> service.setMyCommands(req))
+                .isSameAs(err);
+        verify(client).setMyCommands(req);
+        verifyNoMoreInteractions(client);
+    }
+
+}

--- a/src/test/java/com/roman3455/deplifybot/service/telegram/TelegramClientServiceValidationTest.java
+++ b/src/test/java/com/roman3455/deplifybot/service/telegram/TelegramClientServiceValidationTest.java
@@ -1,0 +1,124 @@
+package com.roman3455.deplifybot.service.telegram;
+
+import com.roman3455.deplifybot.client.TelegramClient;
+import com.roman3455.deplifybot.dto.telegram.api.request.BotDescriptionRequest;
+import com.roman3455.deplifybot.dto.telegram.api.request.BotShortDescriptionRequest;
+import com.roman3455.deplifybot.dto.telegram.api.request.SetMyCommandsRequest;
+import com.roman3455.deplifybot.dto.telegram.api.request.SetWebhookRequest;
+import com.roman3455.deplifybot.service.telegram.impl.TelegramClientServiceImpl;
+import jakarta.validation.ConstraintViolationException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.validation.beanvalidation.MethodValidationPostProcessor;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = TelegramClientServiceValidationTest.Config.class)
+@DisplayName("TelegramClientService — method validation")
+class TelegramClientServiceValidationTest {
+
+    @Configuration
+    static class Config {
+
+        @Bean
+        MethodValidationPostProcessor methodValidationPostProcessor() {
+            return new MethodValidationPostProcessor();
+        }
+
+        @Bean
+        TelegramClient telegramClient() {
+            return org.mockito.Mockito.mock(TelegramClient.class);
+        }
+
+        @Bean
+        TelegramClientService service(final TelegramClient client) {
+            return new TelegramClientServiceImpl(client);
+        }
+
+    }
+
+    @Autowired
+    private TelegramClientService service;
+
+    @Autowired
+    private TelegramClient client;
+
+    @Test
+    @DisplayName("setMyDescription(null) -> ConstraintViolationException; client is not called")
+    void setMyDescriptionNullThrowsViolation() {
+        assertThatThrownBy(() -> service.setMyDescription(null))
+                .isInstanceOf(ConstraintViolationException.class);
+        verifyNoInteractions(client);
+    }
+
+    @Test
+    @DisplayName("setMyShortDescription(null) -> ConstraintViolationException; client is not called")
+    void setMyShortDescriptionNullThrowsViolation() {
+        assertThatThrownBy(() -> service.setMyShortDescription(null))
+                .isInstanceOf(ConstraintViolationException.class);
+        verifyNoInteractions(client);
+    }
+
+    @Test
+    @DisplayName("setMyCommands(null) -> ConstraintViolationException; client is not called")
+    void setMyCommandsNullThrowsViolation() {
+        assertThatThrownBy(() -> service.setMyCommands(null))
+                .isInstanceOf(ConstraintViolationException.class);
+        verifyNoInteractions(client);
+    }
+
+    @Test
+    @DisplayName("setWebhook(null) -> ConstraintViolationException; client is not called")
+    void setWebhookNullThrowsViolation() {
+        assertThatThrownBy(() -> service.setWebhook(null))
+                .isInstanceOf(ConstraintViolationException.class);
+        verifyNoInteractions(client);
+    }
+
+    @Test
+    @DisplayName("setMyDescription: ConstraintViolationException (violates @ISO6391); client is not called")
+    void setMyDescriptionInvalidLanguageCodeThrowsViolation() {
+        var invalid = new BotDescriptionRequest("desc", "eng");
+        assertThatThrownBy(() -> service.setMyDescription(invalid))
+                .isInstanceOf(ConstraintViolationException.class)
+                .hasMessageContaining("'languageCode' length must be exactly 2 characters.");
+    }
+
+    @Test
+    @DisplayName("setMyShortDescription: ConstraintViolationException (violates @AssertTrue); client is not called")
+    void setMyShortDescriptionNullFieldsThrowsViolation() {
+        var invalid = new BotShortDescriptionRequest(null, null);
+        assertThatThrownBy(() -> service.setMyShortDescription(invalid))
+                .isInstanceOf(ConstraintViolationException.class)
+                .hasMessageContaining("'shortDescription' or 'languageCode' must be provided.");
+    }
+
+    @Test
+    @DisplayName("setMyCommands: ConstraintViolationException (violates @Size); client is not called")
+    void setMyCommandsEmptyListThrowsViolation() {
+        var invalid = new SetMyCommandsRequest(List.of(), null, null);
+        assertThatThrownBy(() -> service.setMyCommands(invalid))
+                .isInstanceOf(ConstraintViolationException.class)
+                .hasMessageContaining("Field 'commands' is required and cannot be empty.");
+        verifyNoInteractions(client);
+    }
+
+    @Test
+    @DisplayName("setWebhook: ConstraintViolationException (violates @Pattern); client is not called")
+    void setWebhookMismatchUlrThrowsViolation() {
+        var invalid = new SetWebhookRequest("http://ex.ru", null, null, null, null);
+        assertThatThrownBy(() -> service.setWebhook(invalid))
+                .isInstanceOf(ConstraintViolationException.class)
+                .hasMessageContaining("must start with 'https://'");
+    }
+}


### PR DESCRIPTION
- TelegramClient:
  - add javadoc
  - add service endpoints
- TelegramClientService encapsulate feign methods
- TelegramClientServiceImpl realize simple interface methods
- test: add validation & delegation service layer tests

Closes: issue-0022