### PR TITLE
feat(i18n): externalize command texts to i18n and align MessageSource configs

### DIFF
--- a/src/main/java/com/roman3455/deplifybot/dto/telegram/api/request/SetMyCommandsRequest.java
+++ b/src/main/java/com/roman3455/deplifybot/dto/telegram/api/request/SetMyCommandsRequest.java
@@ -1,13 +1,11 @@
 package com.roman3455.deplifybot.dto.telegram.api.request;
 
-import com.roman3455.deplifybot.service.telegram.command.CommandType;
 import com.roman3455.deplifybot.util.validator.iso6391.ISO6391;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
 import org.springframework.lang.Nullable;
 
-import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -51,19 +49,6 @@ public record SetMyCommandsRequest(
         commands = List.copyOf(commands.stream()
                 .distinct()
                 .toList());
-    }
-
-    public static SetMyCommandsRequest fromCommandTypes(
-            @Nullable final BotCommandScope scope,
-            @Nullable final String languageCode
-    ) {
-        List<MyCommand> commands = Arrays.stream(CommandType.values())
-                .map(c -> new MyCommand(c.getNameWithoutSlash(), c.getDescription()))
-                .toList();
-        if (commands.size() > MAX_COMMANDS_AMOUNT) {
-            throw new IllegalArgumentException("At most 100 commands allowed.");
-        }
-        return new SetMyCommandsRequest(commands, scope, languageCode);
     }
 
 }

--- a/src/main/java/com/roman3455/deplifybot/service/telegram/BotActionType.java
+++ b/src/main/java/com/roman3455/deplifybot/service/telegram/BotActionType.java
@@ -4,6 +4,6 @@ public interface BotActionType {
 
     String getName();
 
-    String getDescription();
+    String getMessageCode();
 
 }

--- a/src/main/java/com/roman3455/deplifybot/service/telegram/command/CommandType.java
+++ b/src/main/java/com/roman3455/deplifybot/service/telegram/command/CommandType.java
@@ -4,14 +4,14 @@ import com.roman3455.deplifybot.service.telegram.BotActionType;
 
 public enum CommandType implements BotActionType {
 
-    START("/start", "Начало работы");
+    START("/start", "bot.command.start");
 
     private final String name;
-    private final String description;
+    private final String messageCode;
 
-    CommandType(final String name, final String description) {
+    CommandType(final String name, final String messageCode) {
         this.name = name;
-        this.description = description;
+        this.messageCode = messageCode;
     }
 
     @Override
@@ -20,12 +20,12 @@ public enum CommandType implements BotActionType {
     }
 
     @Override
-    public String getDescription() {
-        return description;
+    public String getMessageCode() {
+        return messageCode;
     }
 
     public String getNameWithoutSlash() {
-        return this.name.replace("/", "");
+        return name.replace("/", "");
     }
 
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -9,6 +9,9 @@ spring:
             connect-timeout: 10000
             read-timeout: 15000
 
+  messages:
+    cache-duration: 0s
+
   datasource:
     url: ${DB_DEV_URL}
     username: ${DB_DEV_USERNAME}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -9,6 +9,9 @@ spring:
             connect-timeout: 10000
             read-timeout: 15000
 
+  messages:
+    cache-duration: 15s
+
   datasource:
     url: ${DB_PROD_URL}
     username: ${DB_PROD_USERNAME}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -9,6 +9,9 @@ spring:
             connect-timeout: 500
             read-timeout: 500
 
+  messages:
+    cache-duration: 0s
+
   datasource:
     url: ${DB_TEST_URL}
     username: ${DB_TEST_USERNAME}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,11 @@ spring:
   application:
     name: deplifybot
 
+  messages:
+    basename: i18n/messages
+    encoding: UTF-8
+    fallback-to-system-locale: false
+
   cloud:
     openfeign:
       httpclient:
@@ -20,6 +25,8 @@ spring:
 
 telegram:
   bot:
+    connections:
+      value: 40
     webhook:
       path: /telegram/webhook
     token:

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -1,0 +1,9 @@
+# === Init messages ===
+bot.description=The bot helps developers stay up to date with GitHub 🐙 and Docker Hub 🐳 events.\n\nIt allows you to \
+  subscribe to events (PRs, reviews, tags, etc.), manage subscriptions and receive fast notifications in Telegram.\n\
+  It supports both private 👤 and group chats 👥.\n\nPress /start to set up your subscriptions and start receiving \
+  notifications.
+bot.short-description=GitHub & Docker Hub updates in Telegram\n\nMore information in the repository:\n\
+  https://github.com/Roman3455/DeplifyBot
+# === Bot commands ===
+bot.command.start=Get started with the bot

--- a/src/main/resources/i18n/messages_en.properties
+++ b/src/main/resources/i18n/messages_en.properties
@@ -1,0 +1,9 @@
+# === Init messages ===
+bot.description=The bot helps developers stay up to date with GitHub 🐙 and Docker Hub 🐳 events.\n\nIt allows you to \
+  subscribe to events (PRs, reviews, tags, etc.), manage subscriptions and receive fast notifications in Telegram.\n\
+  It supports both private 👤 and group chats 👥.\n\nPress /start to set up your subscriptions and start receiving \
+  notifications.
+bot.short-description=GitHub & Docker Hub updates in Telegram\n\nMore information in the repository:\n\
+  https://github.com/Roman3455/DeplifyBot
+# === Bot commands ===
+bot.command.start=Get started with the bot

--- a/src/main/resources/i18n/messages_ru.properties
+++ b/src/main/resources/i18n/messages_ru.properties
@@ -1,0 +1,8 @@
+# === Init messages ===
+bot.description=Бот помогает разработчикам быть в курсе событий GitHub 🐙 и Docker Hub 🐳.\n\nПозволяет подписываться \
+  на события (PR, review, tags и пр.), управлять подписками и получать быстрые уведомления в Telegram.\nПоддерживает \
+  личные 👤 и групповые чаты 👥.\n\nНажмите /start, чтобы настроить подписки и получать уведомления.
+bot.short-description=GitHub & Docker Hub updates in Telegram\n\nБольше информации в GitHub репозитории:\n\
+  https://github.com/Roman3455/DeplifyBot
+# === Bot commands ===
+bot.command.start=Начало работы с ботом


### PR DESCRIPTION
- application-*.yml:
  - add messages section (basename, encoding, fallback, cache)
  - add telegram.bot.connections.value=40
- BotActionType:
  - change getDescription() -> getMessageCode()
- CommandType:
  - adaptate description feat to message bandles
- SetMyCommandsRequest:
  - remove fromCommandTypes(...) method
- messages*.properties (base, en, ru):
  - add init messages
  - add start command description

Closes: issue-0024