### PR TITLE
fix(test): add Telegram Feign Config test & fix Sonar issues

### DIFF
--- a/src/main/java/com/roman3455/deplifybot/configuration/BotInitializer.java
+++ b/src/main/java/com/roman3455/deplifybot/configuration/BotInitializer.java
@@ -186,16 +186,16 @@ public class BotInitializer {
      * @param actionLabel     label for logs/exceptions (e.g., {@code "description"}).
      * @param apiCall         function to perform API call (transport errors are caught and wrapped).
      * @param requestSupplier supplier to build per-locale request.
-     * @param <TReq>          request type (e.g., {@link BotDescriptionRequest}).
+     * @param <R>          request type (e.g., {@link BotDescriptionRequest}).
      * @throws BotInitializationException on transport or domain error.
      */
-    private <TReq> void setForLocales(
+    private <R> void setForLocales(
             final String actionLabel,
-            final Function<TReq, ResponseBody<Boolean>> apiCall,
-            final Function<LanguageSpec, TReq> requestSupplier
+            final Function<R, ResponseBody<Boolean>> apiCall,
+            final Function<LanguageSpec, R> requestSupplier
     ) {
         LANGUAGE_SPECS.forEach(spec -> {
-            TReq request = requestSupplier.apply(spec);
+            R request = requestSupplier.apply(spec);
             ResponseBody<Boolean> response;
             try {
                 response = apiCall.apply(request);

--- a/src/main/java/com/roman3455/deplifybot/exception/telegram/TelegramApiException.java
+++ b/src/main/java/com/roman3455/deplifybot/exception/telegram/TelegramApiException.java
@@ -7,7 +7,7 @@ package com.roman3455.deplifybot.exception.telegram;
  */
 public abstract class TelegramApiException extends RuntimeException {
 
-    public TelegramApiException(final String message) {
+    protected TelegramApiException(final String message) {
         super(message);
     }
 

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -43,17 +43,8 @@
             </encoder>
         </appender>
 
-        <!--
-        <appender name="JSON" class="ch.qos.logback.core.ConsoleAppender">
-            <encoder class="net.logstash.logback.encoder.LogstashEncoder">
-                <customFields>{"app":"${APP_NAME}","env":"${APP_ENV}"}</customFields>
-            </encoder>
-        </appender>
-        -->
-
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
-            <!-- <appender-ref ref="JSON"/> -->
         </root>
     </springProfile>
 

--- a/src/test/java/com/roman3455/deplifybot/configuration/JacksonConfigurationTest.java
+++ b/src/test/java/com/roman3455/deplifybot/configuration/JacksonConfigurationTest.java
@@ -1,4 +1,4 @@
-package com.roman3455.deplifybot.configuration.jackson;
+package com.roman3455.deplifybot.configuration;
 
 import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/test/java/com/roman3455/deplifybot/configuration/TelegramFeignConfigTest.java
+++ b/src/test/java/com/roman3455/deplifybot/configuration/TelegramFeignConfigTest.java
@@ -1,0 +1,44 @@
+package com.roman3455.deplifybot.configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.roman3455.deplifybot.exception.TelegramErrorDecoder;
+import feign.codec.ErrorDecoder;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("TelegramFeignConfig — object mapper behavior")
+class TelegramFeignConfigTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withBean(ObjectMapper.class, ObjectMapper::new)
+            .withUserConfiguration(TelegramFeignConfig.class);
+
+    @Test
+    @DisplayName("Provides TelegramErrorDecoder bean when ObjectMapper is present")
+    void providesTelegramErrorDecoderBean() {
+        contextRunner.run(ctx -> {
+            assertThat(ctx).hasSingleBean(ErrorDecoder.class);
+            ErrorDecoder decoder = ctx.getBean(ErrorDecoder.class);
+            assertThat(decoder).isInstanceOf(TelegramErrorDecoder.class);
+            ErrorDecoder decoder2 = ctx.getBean(ErrorDecoder.class);
+            assertThat(decoder2).isSameAs(decoder);
+        });
+    }
+
+    @Test
+    @DisplayName("Context fails when no ObjectMapper bean is available")
+    void failsToStartWithoutObjectMapper() {
+        new ApplicationContextRunner()
+                .withUserConfiguration(TelegramFeignConfig.class)
+                .run(ctx -> {
+                    assertThat(ctx).hasFailed();
+                    assertThat(ctx).getFailure()
+                            .hasRootCauseInstanceOf(NoSuchBeanDefinitionException.class);
+                });
+    }
+
+}

--- a/src/test/java/com/roman3455/deplifybot/dto/telegram/api/request/BotDescriptionRequestValidationTest.java
+++ b/src/test/java/com/roman3455/deplifybot/dto/telegram/api/request/BotDescriptionRequestValidationTest.java
@@ -3,6 +3,11 @@ package com.roman3455.deplifybot.dto.telegram.api.request;
 import com.roman3455.deplifybot.util.ValidationTestSupport;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
 
 @DisplayName("Bean Validation of BotDescriptionRequest")
 class BotDescriptionRequestValidationTest extends ValidationTestSupport {
@@ -24,31 +29,39 @@ class BotDescriptionRequestValidationTest extends ValidationTestSupport {
         assertViolationContains(invalid, field, messageTemplate);
     }
 
-    @Test
-    @DisplayName("Field 'languageCode' @ISO6391: Unexisted language code should fail")
-    void languageCodeConstraintUnexisted() {
-        final String field = "languageCode";
-        final String messageTemplate = "{ISO6391.languageCode.message}";
-        var invalid = new BotDescriptionRequest(null, "xx");
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("invalidBotDescriptionCases")
+    @DisplayName("BotDescriptionRequest — bean validation failures")
+    void validationFails(
+            final String caseName,
+            final BotDescriptionRequest invalid,
+            final String field,
+            final String messageTemplate
+    ) {
         assertViolationContains(invalid, field, messageTemplate);
     }
 
-    @Test
-    @DisplayName("Field 'languageCode' @ISO6391: Invalid language code length should fail")
-    void languageCodeConstraintInvalid() {
-        final String field = "languageCode";
-        final String messageTemplate = "{ISO6391.languageCode.message}";
-        var invalid = new BotDescriptionRequest(null, "eng");
-        assertViolationContains(invalid, field, messageTemplate);
-    }
-
-    @Test
-    @DisplayName("Fields 'description' and 'languageCode' @AssertTrue: Both null value should fail")
-    void invalidWhenBothNull() {
-        final String field = "anyProvided";
-        final String messageTemplate = "{BotDescriptionRequest.isAnyProvided.AssertTrue}";
-        var invalid = new BotDescriptionRequest(null, null);
-        assertViolationContains(invalid, field, messageTemplate);
+    static Stream<Arguments> invalidBotDescriptionCases() {
+        return Stream.of(
+                Arguments.of(
+                        "ISO6391: unknown language code 'xx'",
+                        new BotDescriptionRequest(null, "xx"),
+                        "languageCode",
+                        "{ISO6391.languageCode.message}"
+                ),
+                Arguments.of(
+                        "ISO6391: invalid length 'eng'",
+                        new BotDescriptionRequest(null, "eng"),
+                        "languageCode",
+                        "{ISO6391.languageCode.message}"
+                ),
+                Arguments.of(
+                        "@AssertTrue: both description and languageCode are null",
+                        new BotDescriptionRequest(null, null),
+                        "anyProvided",
+                        "{BotDescriptionRequest.isAnyProvided.AssertTrue}"
+                )
+        );
     }
 
 }

--- a/src/test/java/com/roman3455/deplifybot/dto/telegram/api/request/BotShortDescriptionRequestValidationTest.java
+++ b/src/test/java/com/roman3455/deplifybot/dto/telegram/api/request/BotShortDescriptionRequestValidationTest.java
@@ -3,6 +3,11 @@ package com.roman3455.deplifybot.dto.telegram.api.request;
 import com.roman3455.deplifybot.util.ValidationTestSupport;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
 
 @DisplayName("Bean Validation of BotShortDescriptionRequest")
 class BotShortDescriptionRequestValidationTest extends ValidationTestSupport {
@@ -24,31 +29,39 @@ class BotShortDescriptionRequestValidationTest extends ValidationTestSupport {
         assertViolationContains(invalid, field, messageTemplate);
     }
 
-    @Test
-    @DisplayName("Field 'languageCode' @ISO6391: Unexisted language code should fail")
-    void languageCodeConstraintUnexisted() {
-        final String field = "languageCode";
-        final String messageTemplate = "{ISO6391.languageCode.message}";
-        var invalid = new BotShortDescriptionRequest(null, "xx");
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("invalidBotShortDescriptionCases")
+    @DisplayName("BotShortDescriptionRequest — bean validation failures")
+    void validationFails(
+            final String caseName,
+            final BotShortDescriptionRequest invalid,
+            final String field,
+            final String messageTemplate
+    ) {
         assertViolationContains(invalid, field, messageTemplate);
     }
 
-    @Test
-    @DisplayName("Field 'languageCode' @ISO6391: Invalid language code length should fail")
-    void languageCodeConstraintInvalid() {
-        final String field = "languageCode";
-        final String messageTemplate = "{ISO6391.languageCode.message}";
-        var invalid = new BotShortDescriptionRequest(null, "eng");
-        assertViolationContains(invalid, field, messageTemplate);
-    }
-
-    @Test
-    @DisplayName("Fields 'shortDescription' and 'languageCode' @AssertTrue: Both null value should fail")
-    void invalidWhenBothNull() {
-        final String field = "anyProvided";
-        final String messageTemplate = "{BotShortDescriptionRequest.isAnyProvided.AssertTrue}";
-        var invalid = new BotShortDescriptionRequest(null, null);
-        assertViolationContains(invalid, field, messageTemplate);
+    static Stream<Arguments> invalidBotShortDescriptionCases() {
+        return Stream.of(
+                Arguments.of(
+                        "ISO6391: unknown language code 'xx'",
+                        new BotShortDescriptionRequest(null, "xx"),
+                        "languageCode",
+                        "{ISO6391.languageCode.message}"
+                ),
+                Arguments.of(
+                        "ISO6391: invalid language code length 'eng'",
+                        new BotShortDescriptionRequest(null, "eng"),
+                        "languageCode",
+                        "{ISO6391.languageCode.message}"
+                ),
+                Arguments.of(
+                        "@AssertTrue: both shortDescription and languageCode are null",
+                        new BotShortDescriptionRequest(null, null),
+                        "anyProvided",
+                        "{BotShortDescriptionRequest.isAnyProvided.AssertTrue}"
+                )
+        );
     }
 
 }

--- a/src/test/java/com/roman3455/deplifybot/dto/telegram/api/request/SetWebhookRequestValidationTest.java
+++ b/src/test/java/com/roman3455/deplifybot/dto/telegram/api/request/SetWebhookRequestValidationTest.java
@@ -4,8 +4,12 @@ import com.roman3455.deplifybot.dto.telegram.api.enums.UpdateType;
 import com.roman3455.deplifybot.util.ValidationTestSupport;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 @DisplayName("Bean Validation of SetWebhookRequest")
 class SetWebhookRequestValidationTest extends ValidationTestSupport {
@@ -27,31 +31,39 @@ class SetWebhookRequestValidationTest extends ValidationTestSupport {
         assertValid(valid);
     }
 
-    @Test
-    @DisplayName("Field 'url' @NotBlank: Null value should fail")
-    void urlConstraintsNullValue() {
-        final String field = "url";
-        final String messageTemplate = "{jakarta.validation.constraints.NotBlank.message}";
-        var invalid = new SetWebhookRequest(null, null, null, null, null);
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("invalidWebhookUrlCases")
+    @DisplayName("SetWebhookRequest — field 'url' validation failures")
+    void urlConstraintFailures(
+            final String caseName,
+            final SetWebhookRequest invalid,
+            final String field,
+            final String messageTemplate
+    ) {
         assertViolationContains(invalid, field, messageTemplate);
     }
 
-    @Test
-    @DisplayName("Field 'url' @NotBlank: Blank value should fail")
-    void urlConstraintsBlankValue() {
-        final String field = "url";
-        final String messageTemplate = "{jakarta.validation.constraints.NotBlank.message}";
-        var invalid = new SetWebhookRequest("   ", null, null, null, null);
-        assertViolationContains(invalid, field, messageTemplate);
-    }
-
-    @Test
-    @DisplayName("Field 'url' @Pattern: Pattern mismatch should fail")
-    void urlConstraintsMismatchPattern() {
-        final String field = "url";
-        final String messageTemplate = "{SetWebhookRequest.url.Pattern.message}";
-        var invalid = new SetWebhookRequest("http://ok", null, null, null, null);
-        assertViolationContains(invalid, field, messageTemplate);
+    static Stream<Arguments> invalidWebhookUrlCases() {
+        return Stream.of(
+                Arguments.of(
+                        "url @NotBlank: null value",
+                        new SetWebhookRequest(null, null, null, null, null),
+                        "url",
+                        "{jakarta.validation.constraints.NotBlank.message}"
+                ),
+                Arguments.of(
+                        "url @NotBlank: blank value",
+                        new SetWebhookRequest("   ", null, null, null, null),
+                        "url",
+                        "{jakarta.validation.constraints.NotBlank.message}"
+                ),
+                Arguments.of(
+                        "url @Pattern: mismatch",
+                        new SetWebhookRequest("http://ok", null, null, null, null),
+                        "url",
+                        "{SetWebhookRequest.url.Pattern.message}"
+                )
+        );
     }
 
     @SuppressWarnings("DataFlowIssue")

--- a/src/test/java/com/roman3455/deplifybot/service/telegram/TelegramApiTokenServiceTest.java
+++ b/src/test/java/com/roman3455/deplifybot/service/telegram/TelegramApiTokenServiceTest.java
@@ -23,11 +23,11 @@ class TelegramApiTokenServiceTest {
         final int expectedTokenLength = 43;
         String t1 = service.getToken();
         String t2 = service.getToken();
-        assertThat(t1).isNotBlank();
-        assertThat(t1).isEqualTo(t2);
-        assertThat(t1).matches("^[A-Za-z0-9_-]+$");
-        assertThat(t1).doesNotContain("=");
-        assertThat(t1.length()).isEqualTo(expectedTokenLength);
+        assertThat(t1).isNotBlank()
+                .isEqualTo(t2)
+                .matches("^[A-Za-z0-9_-]+$")
+                .doesNotContain("=")
+                .hasSize(expectedTokenLength);
     }
 
     @Test

--- a/src/test/java/com/roman3455/deplifybot/util/CharacterEscapeUtilTest.java
+++ b/src/test/java/com/roman3455/deplifybot/util/CharacterEscapeUtilTest.java
@@ -1,18 +1,27 @@
 package com.roman3455.deplifybot.util;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@DisplayName("CharacterEscapeUtil")
 class CharacterEscapeUtilTest {
 
     @Test
+    @DisplayName("escapeMarkdownV2: null or empty → empty string")
     void escapeMarkdownV2NullOrEmptyReturnsEmpty() {
         assertEquals("", CharacterEscapeUtil.escapeMarkdownV2(null));
         assertEquals("", CharacterEscapeUtil.escapeMarkdownV2(""));
     }
 
     @Test
+    @DisplayName("escapeMarkdownV2: all special characters are escaped")
     void escapeMarkdownV2EscapesAllSpecials() {
         String input = "_[]()~`>#+=-|{}.!*";
         String expected = "\\_\\[\\]\\(\\)\\~\\`\\>\\#\\+\\=\\-\\|\\{\\}\\.\\!\\*";
@@ -20,6 +29,7 @@ class CharacterEscapeUtilTest {
     }
 
     @Test
+    @DisplayName("escapeMarkdownV2: mixed text is correctly escaped")
     void escapeMarkdownV2MixedTextIsEscaped() {
         String input = "Hello *world*! [link](url) a_b c-d {x}";
         String expected = "Hello \\*world\\*\\! \\[link\\]\\(url\\) a\\_b c\\-d \\{x\\}";
@@ -27,36 +37,48 @@ class CharacterEscapeUtilTest {
     }
 
     @Test
+    @DisplayName("escapeMarkdownV2: safe chars and Unicode remain untouched")
     void escapeMarkdownV2UnicodeAndSafeCharsRemainUntouched() {
         String input = "Hello world 123 😊";
         assertEquals(input, CharacterEscapeUtil.escapeMarkdownV2(input));
     }
 
     @Test
+    @DisplayName("escapeHtml: null or empty → empty string")
     void escapeHtmlNullOrEmptyReturnsEmpty() {
         assertEquals("", CharacterEscapeUtil.escapeHtml(null));
         assertEquals("", CharacterEscapeUtil.escapeHtml(""));
     }
 
-    @Test
-    void escapeHtmlEscapesAllReserved() {
-        String input = "&<>\"'";
-        String expected = "&amp;&lt;&gt;&quot;&#x27;";
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("escapeHtmlCases")
+    @DisplayName("CharacterEscapeUtil.escapeHtml() — escaping scenarios")
+    void escapeHtmlParameterized(
+            final String caseName,
+            final String input,
+            final String expected
+    ) {
         assertEquals(expected, CharacterEscapeUtil.escapeHtml(input));
     }
 
-    @Test
-    void escapeHtmlMixedTextIsEscaped() {
-        String input = "Hello & <b>bold</b> 'q'";
-        String expected = "Hello &amp; &lt;b&gt;bold&lt;/b&gt; &#x27;q&#x27;";
-        assertEquals(expected, CharacterEscapeUtil.escapeHtml(input));
-    }
-
-    @Test
-    void escapeHtmlAmpersandHandledFirstNoDoubleEscape() {
-        String input = "&<";
-        String expected = "&amp;&lt;";
-        assertEquals(expected, CharacterEscapeUtil.escapeHtml(input));
+    static Stream<Arguments> escapeHtmlCases() {
+        return Stream.of(
+                Arguments.of(
+                        "Escapes all reserved characters",
+                        "&<>\"'",
+                        "&amp;&lt;&gt;&quot;&#x27;"
+                ),
+                Arguments.of(
+                        "Mixed text is escaped correctly",
+                        "Hello & <b>bold</b> 'q'",
+                        "Hello &amp; &lt;b&gt;bold&lt;/b&gt; &#x27;q&#x27;"
+                ),
+                Arguments.of(
+                        "Ampersand handled first (no double escape)",
+                        "&<",
+                        "&amp;&lt;"
+                )
+        );
     }
 
 }

--- a/src/test/java/com/roman3455/deplifybot/util/ValidationTestSupport.java
+++ b/src/test/java/com/roman3455/deplifybot/util/ValidationTestSupport.java
@@ -80,7 +80,7 @@ public abstract class ValidationTestSupport {
         assertThat(violations)
                 .as("Expected violation on '%s' containing '%s'", field, messageTemplate)
                 .anySatisfy(v -> {
-                    assertThat(v.getPropertyPath().toString()).isEqualTo(field);
+                    assertThat(v.getPropertyPath()).hasToString(field);
                     assertThat(v.getMessageTemplate()).contains(messageTemplate);
                 });
     }


### PR DESCRIPTION
- java:S5976:
  - BotDescriptionRequestValidationTest
  - BotShortDescriptionRequestValidationTest
  - SetWebhookRequestValidationTest
  - CharacterEscapeUtilTest
- java:S119:
  - BotInitializer
- JacksonConfigurationTest:
  - move .configuration.jackson to .configuration
- logback-spring.xml:
  - remove JSON logger
- TelegramApiException:
  - change constructor to protected
- java:S5853, 5838:
  - TelegramApiTokenService
  - ValidationTestSupport
- add TelegramFeignConfigTest

Closes: issue-0028