### PR TITLE
feat(api): add Telegram Update DTO with internal DTOs & enums

### DIFF
--- a/src/main/java/com/roman3455/deplifybot/dto/telegram/api/enums/ChatMemberStatusType.java
+++ b/src/main/java/com/roman3455/deplifybot/dto/telegram/api/enums/ChatMemberStatusType.java
@@ -1,0 +1,80 @@
+package com.roman3455.deplifybot.dto.telegram.api.enums;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.roman3455.deplifybot.util.enums.JsonEnum;
+import com.roman3455.deplifybot.util.enums.JsonEnumUtil;
+
+/**
+ * Represents the membership status of a user within a chat, as defined by the Telegram Bot API.
+ *
+ * <p>Each constant corresponds to a specific access level or state in the chat. The enum maps directly to
+ * lowercase values found in JSON payloads. The {@link #UNKNOWN} value provides forward compatibility in
+ * case of new status types introduced by Telegram.</p>
+ *
+ * @see <a href="https://core.telegram.org/bots/api#chatmember">Telegram API — ChatMember</a>
+ * @see com.roman3455.deplifybot.util.enums.JsonEnum
+ * @see com.roman3455.deplifybot.util.enums.JsonEnumUtil
+ */
+public enum ChatMemberStatusType implements JsonEnum {
+
+    /**
+     * The user is an administrator in the chat.
+     */
+    ADMINISTRATOR("administrator"),
+
+    /**
+     * The user is the creator (owner) of the chat.
+     */
+    CREATOR("creator"),
+
+    /**
+     * The user has been kicked from the chat and cannot return.
+     */
+    KICKED("kicked"),
+
+    /**
+     * The user has left the chat.
+     */
+    LEFT("left"),
+
+    /**
+     * The user is a regular member of the chat.
+     */
+    MEMBER("member"),
+
+    /**
+     * The user is restricted and has limited interaction rights.
+     */
+    RESTRICTED("restricted"),
+
+    /**
+     * Fallback for unrecognized or newly introduced membership states.
+     */
+    UNKNOWN("unknown");
+
+    private final String value;
+
+    ChatMemberStatusType(final String value) {
+        this.value = value;
+    }
+
+    /**
+     * @return the string value used for JSON serialization and matching against Telegram API payloads.
+     */
+    @Override
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Resolves a {@code ChatMemberStatusType} from its string value.
+     *
+     * @param value the string value from the incoming JSON payload.
+     * @return the corresponding {@code ChatMemberStatusType}, or {@link #UNKNOWN} if no match is found.
+     */
+    @JsonCreator
+    public static ChatMemberStatusType fromValue(final String value) {
+        return JsonEnumUtil.fromValue(ChatMemberStatusType.class, value, UNKNOWN);
+    }
+
+}

--- a/src/main/java/com/roman3455/deplifybot/dto/telegram/api/enums/ChatType.java
+++ b/src/main/java/com/roman3455/deplifybot/dto/telegram/api/enums/ChatType.java
@@ -1,0 +1,70 @@
+package com.roman3455.deplifybot.dto.telegram.api.enums;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.roman3455.deplifybot.util.enums.JsonEnum;
+import com.roman3455.deplifybot.util.enums.JsonEnumUtil;
+
+/**
+ * Represents the supported chat types returned by the Telegram Bot API.
+ *
+ * <p>Each constant is mapped to its corresponding lowercase string value, matching the JSON payload received
+ * from Telegram. The {@link #UNKNOWN} value acts as a fallback for any unrecognized or future chat types,
+ * ensuring forward compatibility and safe deserialization.</p>
+ *
+ * @see <a href="https://core.telegram.org/bots/api#chat">Telegram Bot API — Chat</a>
+ * @see com.roman3455.deplifybot.util.enums.JsonEnum
+ * @see com.roman3455.deplifybot.util.enums.JsonEnumUtil
+ */
+public enum ChatType implements JsonEnum {
+
+    /**
+     * A private chat between the bot and a single user.
+     */
+    PRIVATE("private"),
+
+    /**
+     * A basic group chat.
+     */
+    GROUP("group"),
+
+    /**
+     * A supergroup chat, which may support additional features such as message topics.
+     */
+    SUPERGROUP("supergroup"),
+
+    /**
+     * A broadcast channel. Messages in channels appear as posts without a reply UI by default.
+     */
+    CHANNEL("channel"),
+
+    /**
+     * Fallback for unrecognized or new chat types.
+     */
+    UNKNOWN("unknown");
+
+    private final String value;
+
+    ChatType(final String value) {
+        this.value = value;
+    }
+
+    /**
+     * @return the string value used for JSON serialization and matching against Telegram API payloads.
+     */
+    @Override
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Resolves a {@code ChatType} from its string value.
+     *
+     * @param value the string value from the incoming JSON payload.
+     * @return the corresponding {@code ChatType}, or {@link #UNKNOWN} if no match is found.
+     */
+    @JsonCreator
+    public static ChatType fromValue(final String value) {
+        return JsonEnumUtil.fromValue(ChatType.class, value, UNKNOWN);
+    }
+
+}

--- a/src/main/java/com/roman3455/deplifybot/dto/telegram/api/response/CallbackQuery.java
+++ b/src/main/java/com/roman3455/deplifybot/dto/telegram/api/response/CallbackQuery.java
@@ -1,0 +1,38 @@
+package com.roman3455.deplifybot.dto.telegram.api.response;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.lang.Nullable;
+
+/**
+ * DTO represents an incoming callback query from the Telegram Bot API.
+ *
+ * <p>Callback queries are sent to the bot when a user presses an inline button attached to a message.
+ * Each callback query carries a unique {@code id} and information about the user who triggered it,
+ * along with either the original message or an identifier for an inline message.</p>
+ *
+ * @param id              required. Unique identifier for this query.
+ * @param from            required. The {@link User} who triggered the callback. Contains information about the
+ *                        user and their account.
+ * @param message         optional. The {@link Message} associated with the callback. Present only if the button
+ *                        was attached to a standard chat message.
+ * @param inlineMessageId optional. Identifier of the message in case the callback originated from an
+ *                        inline message. Used for editing messages sent via inline mode.
+ * @param data            optional. The callback data payload specified when the button was created.
+ * @see <a href="https://core.telegram.org/bots/api#callbackquery">Telegram API — CallbackQuery</a>
+ */
+public record CallbackQuery(
+
+        @NotNull
+        String id,
+        @NotNull
+        @Valid User from,
+        @Nullable
+        @Valid Message message,
+        @Nullable
+        String inlineMessageId,
+        @Nullable
+        String data
+
+) {
+}

--- a/src/main/java/com/roman3455/deplifybot/dto/telegram/api/response/Chat.java
+++ b/src/main/java/com/roman3455/deplifybot/dto/telegram/api/response/Chat.java
@@ -1,0 +1,40 @@
+package com.roman3455.deplifybot.dto.telegram.api.response;
+
+import com.roman3455.deplifybot.dto.telegram.api.enums.ChatType;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.lang.Nullable;
+
+/**
+ * DTO represents a chat object from the Telegram Bot API.
+ *
+ * <p>A chat can represent a private conversation, a group, a supergroup, or a channel. Depending on the
+ * chat type, certain fields may be present or absent. For example, private chats include the user's first
+ * name, while group and channel chats may have a title and a public username.</p>
+ *
+ * @param id        required. Unique identifier for this chat.
+ * @param type      required. Type of the chat (private, group, supergroup, or channel).
+ * @param title     optional. Chat title, present for group chats, supergroups, and channels.
+ * @param username  optional. Public username of the chat, without the leading {@code @}. Present only if
+ *                  the chat has one (channels, supergroups, some groups, and some users).
+ * @param firstName optional. First name of the other party in a private chat. Present only for private chats.
+ * @param isForum   optional. Indicates whether the chat is a forum supergroup where topics are enabled.
+ *                  Present only for supergroups with forum mode turned on.
+ * @see <a href="https://core.telegram.org/bots/api#chat">Telegram API — Chat</a>
+ */
+public record Chat(
+
+        @NotNull
+        Long id,
+        @NotNull
+        ChatType type,
+        @Nullable
+        String title,
+        @Nullable
+        String username,
+        @Nullable
+        String firstName,
+        @Nullable
+        Boolean isForum
+
+) {
+}

--- a/src/main/java/com/roman3455/deplifybot/dto/telegram/api/response/ChatMember.java
+++ b/src/main/java/com/roman3455/deplifybot/dto/telegram/api/response/ChatMember.java
@@ -1,0 +1,28 @@
+package com.roman3455.deplifybot.dto.telegram.api.response;
+
+import com.roman3455.deplifybot.dto.telegram.api.enums.ChatMemberStatusType;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * DTO represents a chat member object from the Telegram Bot API.
+ *
+ * <p>This object describes a user's current status within a chat. The status may reflect whether the user is
+ * the chat creator, an administrator, a regular member, or restricted in some way. Combined with
+ * {@link ChatMemberUpdated}, it allows the application to determine what permissions or actions are available
+ * to the user in that chat.</p>
+ *
+ * @param status required. The role or membership state of the user in the chat.
+ * @param user   required. The user to whom this membership record applies.
+ * @see <a href="https://core.telegram.org/bots/api#chatmember">Telegram API — ChatMember</a>
+ * @see ChatMemberStatusType
+ */
+public record ChatMember(
+
+        @NotNull
+        ChatMemberStatusType status,
+        @NotNull
+        @Valid User user
+
+) {
+}

--- a/src/main/java/com/roman3455/deplifybot/dto/telegram/api/response/ChatMemberUpdated.java
+++ b/src/main/java/com/roman3455/deplifybot/dto/telegram/api/response/ChatMemberUpdated.java
@@ -1,0 +1,37 @@
+package com.roman3455.deplifybot.dto.telegram.api.response;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.Instant;
+
+/**
+ * DTO represents an update about a user's or the bot's chat member status.
+ *
+ * <p>This object is delivered when the membership status of a user (including the bot) changes within a chat.
+ * Such changes may include joining, leaving, being promoted or demoted, or being restricted. The update contains
+ * both the previous and the new membership state, allowing the application to determine what exactly has changed.</p>
+ *
+ * @param chat          required. The chat in which the member status was updated.
+ * @param from          required. The user who performed the action that caused the change (e.g., an admin who
+ *                      promoted or restricted another user).
+ * @param date          required. The timestamp when the change occurred.
+ * @param oldChatMember required. The previous chat member state before the update.
+ * @param newChatMember required. The new chat member state after the update.
+ * @see <a href="https://core.telegram.org/bots/api#chatmemberupdated">Telegram API — ChatMemberUpdated</a>
+ */
+public record ChatMemberUpdated(
+
+        @NotNull
+        @Valid Chat chat,
+        @NotNull
+        @Valid User from,
+        @NotNull
+        Instant date,
+        @NotNull
+        @Valid ChatMember oldChatMember,
+        @NotNull
+        @Valid ChatMember newChatMember
+
+) {
+}

--- a/src/main/java/com/roman3455/deplifybot/dto/telegram/api/response/ChatShared.java
+++ b/src/main/java/com/roman3455/deplifybot/dto/telegram/api/response/ChatShared.java
@@ -1,0 +1,33 @@
+package com.roman3455.deplifybot.dto.telegram.api.response;
+
+import jakarta.validation.constraints.NotNull;
+import org.springframework.lang.Nullable;
+
+/**
+ * DTO represents a shared chat object received via the chat request feature of the Telegram Bot API.
+ *
+ * <p>This object is delivered when a user selects and shares a chat with the bot in response to a button
+ * configured with {@code request_chat}. It contains identifiers that allow the bot to reference and interact
+ * with the shared chat, as well as optional metadata such as a title or username.</p>
+ *
+ * @param requestId required. Identifier of the request that triggered the chat selection. Matches the value
+ *                  defined when the bot requested chat sharing.
+ * @param chatId    required. Unique identifier of the shared chat.
+ * @param title     optional. The title of the chat (e.g., group or channel name). Present for non-private chats.
+ * @param username  optional. The public username of the chat, without the leading {@code @}. Present only if
+ *                  the chat has a public handle.
+ * @see <a href="https://core.telegram.org/bots/api#chatshared">Telegram API — ChatShared</a>
+ */
+public record ChatShared(
+
+        @NotNull
+        Long requestId,
+        @NotNull
+        Long chatId,
+        @Nullable
+        String title,
+        @Nullable
+        String username
+
+) {
+}

--- a/src/main/java/com/roman3455/deplifybot/dto/telegram/api/response/Message.java
+++ b/src/main/java/com/roman3455/deplifybot/dto/telegram/api/response/Message.java
@@ -1,0 +1,63 @@
+package com.roman3455.deplifybot.dto.telegram.api.response;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.lang.Nullable;
+
+import java.time.Instant;
+
+/**
+ * DTO represents an incoming message from the Telegram Bot API.
+ *
+ * <p>A message may contain text or other types of content. Depending on the source and context,
+ * it may also include thread information (for topics), sender data, chat metadata, and migration
+ * identifiers when groups are converted to supergroups.</p>
+ *
+ * @param messageId         required. Unique identifier for this message within the chat.
+ * @param messageThreadId   optional. Identifier of the thread the message belongs to. Present only if the
+ *                          chat supports message threading (e.g. forum topics).
+ * @param from              optional. Sender of the message. For outgoing messages sent by the bot itself,
+ *                          this field may be missing.
+ * @param date              required. Timestamp when the message was sent.
+ * @param chat              required. The chat where the message belongs.
+ * @param text              optional. Text content of the message. Present only if the message contains text.
+ * @param migrateToChatId   optional. Indicates that the chat has been migrated to a new supergroup with the
+ *                          provided identifier. Present in service messages only.
+ * @param migrateFromChatId optional. Indicates that the current message was sent in a chat that migrated
+ *                          from another chat identifier. Present in service messages only.
+ * @param chatShared        optional. Contains information about a chat shared via the chat request feature.
+ * @see <a href="https://core.telegram.org/bots/api#message">Telegram API — Message</a>
+ */
+public record Message(
+
+        @NotNull
+        Long messageId,
+        @Nullable
+        Long messageThreadId,
+        @Nullable
+        @Valid User from,
+        @NotNull
+        Instant date,
+        @NotNull
+        @Valid Chat chat,
+        @Nullable
+        String text,
+        @Nullable
+        Long migrateToChatId,
+        @Nullable
+        Long migrateFromChatId,
+        @Nullable
+        @Valid ChatShared chatShared
+
+) {
+
+    /**
+     * Check if the message contains non-empty text content.
+     *
+     * @return {@code true} if {@link #text} is not {@code null} and not blank.
+     */
+    public boolean hasText() {
+        return this.text != null && !this.text.isBlank();
+    }
+
+}

--- a/src/main/java/com/roman3455/deplifybot/dto/telegram/api/response/Update.java
+++ b/src/main/java/com/roman3455/deplifybot/dto/telegram/api/response/Update.java
@@ -1,0 +1,86 @@
+package com.roman3455.deplifybot.dto.telegram.api.response;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import org.springframework.lang.Nullable;
+
+/**
+ * DTO represents an incoming update from the Telegram Bot API.
+ *
+ * <p>Each update carries a unique {@code updateId} and may contain one of several optional payloads depending on
+ * the event type. At most one of the optional parameters can be present in any given update.</p>
+ *
+ * @param updateId      required. The update's unique identifier. It allows you to ignore repeated updates or to
+ *                      restore the correct update sequence.
+ * @param message       optional. New incoming message of any kind - text, photo, sticker, etc.
+ * @param callbackQuery optional. New incoming callback query.
+ * @param myChatMember  optional. The bot's chat member status was updated in a chat. For private chats, this
+ *                      update is received only when the bot is blocked or unblocked by the user.
+ * @see <a href="https://core.telegram.org/bots/api#update">Telegram API — Update</a>
+ */
+public record Update(
+
+        @NotNull
+        @Positive
+        long updateId,
+        @Nullable
+        @Valid Message message,
+        @Nullable
+        @Valid CallbackQuery callbackQuery,
+        @Nullable
+        @Valid ChatMemberUpdated myChatMember
+
+) {
+
+    /**
+     * Check if update contains message.
+     *
+     * @return {@code true} if {@link #message} is not {@code null}.
+     */
+    public boolean hasMessage() {
+        return this.message != null;
+    }
+
+    /**
+     * Check if update contains callback query.
+     *
+     * @return {@code true} if {@link #callbackQuery} is not {@code null}.
+     */
+    public boolean hasCallbackQuery() {
+        return this.callbackQuery != null;
+    }
+
+    /**
+     * Check if update contains my chat member.
+     *
+     * @return {@code true} if {@link #myChatMember} is not {@code null}.
+     */
+    public boolean hasMyChatMember() {
+        return this.myChatMember != null;
+    }
+
+    /**
+     * Cross-field constraint: require at most one of the optional field to be provided.
+     *
+     * <p>Violation will be reported on the synthetic property named after this method.</p>
+     *
+     * @return {@code true} if only one of the optional is not {@code null}.
+     */
+    @AssertTrue(message = "{Update.isAnyProvided.AssertTrue}")
+    private boolean isAnyProvided() {
+        int filledOptionalFields = 0;
+        if (message != null) {
+            filledOptionalFields++;
+        }
+        if (callbackQuery != null) {
+            filledOptionalFields++;
+        }
+        if (myChatMember != null) {
+            filledOptionalFields++;
+        }
+        return filledOptionalFields == 1;
+    }
+
+}

--- a/src/main/java/com/roman3455/deplifybot/dto/telegram/api/response/User.java
+++ b/src/main/java/com/roman3455/deplifybot/dto/telegram/api/response/User.java
@@ -1,0 +1,37 @@
+package com.roman3455.deplifybot.dto.telegram.api.response;
+
+import com.roman3455.deplifybot.util.validator.iso6391.ISO6391;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.lang.Nullable;
+
+/**
+ * DTO represents a Telegram user or bot account.
+ *
+ * <p>It contains the unique identifier of the user, basic profile information, and an optional language code.
+ * The {@code isBot} flag distinguishes regular users from automated bot accounts. The language code, when present,
+ * follows the ISO 639-1 standard and can be used for localization decisions.</p>
+ *
+ * @param id           required. Unique identifier for this user or bot.
+ * @param isBot        required. Indicates whether this account belongs to a bot.
+ * @param firstName    required. The user’s first name as displayed in their Telegram profile.
+ * @param username     optional. The Telegram username, without the leading {@code @}. Present only if the user has
+ *                     chosen to set it.
+ * @param languageCode optional. The user’s language in ISO 639-1 format (e.g., {@code "en"}, {@code "ru"}).
+ *                     May be used for UI localization or message translations.
+ * @see <a href="https://core.telegram.org/bots/api#user">Telegram API — User</a>
+ */
+public record User(
+
+        @NotNull
+        Long id,
+        boolean isBot,
+        @NotNull
+        String firstName,
+        @Nullable
+        String username,
+        @Nullable
+        @ISO6391(message = "{ISO6391.languageCode.message}")
+        String languageCode
+
+) {
+}

--- a/src/main/resources/i18n/ValidationMessages.properties
+++ b/src/main/resources/i18n/ValidationMessages.properties
@@ -2,6 +2,7 @@
 jakarta.validation.constraints.NotNull.message=must not be null
 jakarta.validation.constraints.NotBlank.message=must not be blank
 jakarta.validation.constraints.NotEmpty.message=must not be empty
+jakarta.validation.constraints.Positive.message=must be greater than 0
 jakarta.validation.constraints.Size.message=size must be between {min} and {max} characters
 # === Common override message patterns ===
 Size.min.message=size must be at least {min} characters
@@ -19,3 +20,4 @@ BotDescriptionRequest.isAnyProvided.AssertTrue=at least one of the fields 'descr
   provided
 BotShortDescriptionRequest.isAnyProvided.AssertTrue=at least one of the fields 'shortDescription' or 'languageCode' \
   must be provided
+Update.isAnyProvided.AssertTrue=at most one of the fields 'message', 'callbackQuery' or 'myChatMember' must be provided

--- a/src/main/resources/i18n/ValidationMessages_en.properties
+++ b/src/main/resources/i18n/ValidationMessages_en.properties
@@ -2,6 +2,7 @@
 jakarta.validation.constraints.NotNull.message=must not be null
 jakarta.validation.constraints.NotBlank.message=must not be blank
 jakarta.validation.constraints.NotEmpty.message=must not be empty
+jakarta.validation.constraints.Positive.message=must be greater than 0
 jakarta.validation.constraints.Size.message=size must be between {min} and {max} characters
 # === Common override message patterns ===
 Size.min.message=size must be at least {min} characters
@@ -19,3 +20,4 @@ BotDescriptionRequest.isAnyProvided.AssertTrue=at least one of the fields 'descr
   provided
 BotShortDescriptionRequest.isAnyProvided.AssertTrue=at least one of the fields 'shortDescription' or 'languageCode' \
   must be provided
+Update.isAnyProvided.AssertTrue=at most one of the fields 'message', 'callbackQuery' or 'myChatMember' must be provided

--- a/src/main/resources/i18n/ValidationMessages_ru.properties
+++ b/src/main/resources/i18n/ValidationMessages_ru.properties
@@ -2,6 +2,7 @@
 jakarta.validation.constraints.NotNull.message=не должно быть null
 jakarta.validation.constraints.NotBlank.message=не должно быть пустым
 jakarta.validation.constraints.NotEmpty.message=не должно быть пустым
+jakarta.validation.constraints.Positive.message=должно быть больше 0
 jakarta.validation.constraints.Size.message=длина должна быть в пределах от {min} до {max} символов
 # === Common override message patterns ===
 Size.min.message=длина должна быть не менее {min} символов
@@ -19,3 +20,4 @@ BotDescriptionRequest.isAnyProvided.AssertTrue=должно быть указа�
   'languageCode'
 BotShortDescriptionRequest.isAnyProvided.AssertTrue=должно быть указано хотя бы одно из полей: 'shortDescription' или \
   'languageCode'
+Update.isAnyProvided.AssertTrue=должно быть не более одного поля 'message', 'callbackQuery' или 'myChatMember'


### PR DESCRIPTION
- also add i18n validation messages:
  - Update.isAnyProvided.AssertTrue
  - jakarta.validation.constraints.Positive

Closes: issue-0029