### PR TITLE
feat (config): create configuration bean for Telegram Bot settings

### DIFF
--- a/src/main/java/com/roman3455/deplifybot/Application.java
+++ b/src/main/java/com/roman3455/deplifybot/Application.java
@@ -1,11 +1,14 @@
 package com.roman3455.deplifybot;
 
+import com.roman3455.deplifybot.configuration.TelegramBotProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @EnableFeignClients
 @SpringBootApplication
+@EnableConfigurationProperties(TelegramBotProperties.class)
 public class Application {
 
     public static void main(String[] args) {

--- a/src/main/java/com/roman3455/deplifybot/configuration/BotInitializer.java
+++ b/src/main/java/com/roman3455/deplifybot/configuration/BotInitializer.java
@@ -16,7 +16,6 @@ import com.roman3455.deplifybot.service.telegram.command.CommandType;
 import feign.FeignException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.MessageSource;
@@ -69,9 +68,7 @@ public class BotInitializer {
     private final MessageSource messageSource;
     private final TelegramClientService clientService;
     private final TelegramApiTokenService tokenService;
-
-    private final String botUrl;
-    private final int maxConnections;
+    private final TelegramBotProperties botProperties;
 
     /**
      * Value object describing one locale variant to be applied to Telegram API.
@@ -87,15 +84,12 @@ public class BotInitializer {
             final MessageSource messageSource,
             final TelegramClientService clientService,
             final TelegramApiTokenService tokenService,
-            @Value("${telegram.bot.webhook.url}") final String webhookUrl,
-            @Value("${telegram.bot.webhook.path}") final String webhookPath,
-            @Value("${telegram.bot.connections.value}") final int maxConnections
+            final TelegramBotProperties botProperties
     ) {
         this.messageSource = messageSource;
         this.clientService = clientService;
         this.tokenService = tokenService;
-        this.botUrl = webhookUrl + webhookPath;
-        this.maxConnections = maxConnections;
+        this.botProperties = botProperties;
     }
 
     /**
@@ -165,7 +159,9 @@ public class BotInitializer {
      * @throws BotInitializationException on transport or domain error.
      */
     private void setBotWebhook() {
-        var request = new SetWebhookRequest(botUrl, maxConnections, null, true, tokenService.getToken());
+        String botUrl = botProperties.webhook().url() + botProperties.webhook().path();
+        int connections = botProperties.connections().value();
+        var request = new SetWebhookRequest(botUrl, connections, null, true, tokenService.getToken());
         ResponseBody<Boolean> responseBody;
         try {
             responseBody = clientService.setWebhook(request);

--- a/src/main/java/com/roman3455/deplifybot/configuration/TelegramBotProperties.java
+++ b/src/main/java/com/roman3455/deplifybot/configuration/TelegramBotProperties.java
@@ -1,0 +1,81 @@
+package com.roman3455.deplifybot.configuration;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import java.util.List;
+
+/**
+ * Configuration properties for Telegram bot integration.
+ *
+ * <p>Bound to the {@code telegram.bot.*} prefix.</p>
+ */
+@Validated
+@ConfigurationProperties(prefix = "telegram.bot")
+public record TelegramBotProperties(
+
+        @NotEmpty
+        List<@NotBlank String> allowedUpdateTypes,
+
+        @NotNull
+        @Valid Connections connections,
+
+        @NotNull
+        @Valid Webhook webhook,
+
+        @NotNull
+        @Valid Token token
+
+) {
+
+    /**
+     * Webhook connection limits.
+     */
+    public record Connections(
+
+            @Min(MIN_CONNECTIONS)
+            @Max(MAX_CONNECTIONS)
+            int value
+
+    ) {
+        private static final int MAX_CONNECTIONS = 100;
+        private static final int MIN_CONNECTIONS = 1;
+    }
+
+    /**
+     * Webhook URL and path used to register the bot endpoint in Telegram.
+     */
+    public record Webhook(
+
+            @NotBlank
+            @Pattern(regexp = "^https://.+$", message = "{SetWebhookRequest.url.Pattern.message}")
+            String url,
+
+            @NotBlank
+            String path
+
+    ) {
+    }
+
+    /**
+     * Parameters used to generate the Telegram API secret token.
+     */
+    public record Token(
+
+            @Min(MIN_BYTES)
+            @Max(MAX_BYTES)
+            int bytesSize
+
+    ) {
+        private static final int MAX_BYTES = 64;
+        private static final int MIN_BYTES = 16;
+    }
+
+}

--- a/src/main/java/com/roman3455/deplifybot/service/telegram/impl/TelegramApiTokenServiceImpl.java
+++ b/src/main/java/com/roman3455/deplifybot/service/telegram/impl/TelegramApiTokenServiceImpl.java
@@ -1,10 +1,9 @@
 package com.roman3455.deplifybot.service.telegram.impl;
 
+import com.roman3455.deplifybot.configuration.TelegramBotProperties;
 import com.roman3455.deplifybot.service.telegram.TelegramApiTokenService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.nio.charset.StandardCharsets;
@@ -24,7 +23,9 @@ public class TelegramApiTokenServiceImpl implements TelegramApiTokenService {
 
     private static final Logger LOG = LoggerFactory.getLogger(TelegramApiTokenServiceImpl.class);
 
-    private final String token;
+    private final TelegramBotProperties botProperties;
+
+    private String token;
 
     /**
      * Creates a new instance with a randomly generated Telegram API secret token.
@@ -32,12 +33,9 @@ public class TelegramApiTokenServiceImpl implements TelegramApiTokenService {
      * <p>The token is generated once per application startup and logged for verification
      * purposes (without exposing the actual value).</p>
      */
-    @Autowired
-    public TelegramApiTokenServiceImpl(@Value("${telegram.bot.token.bytes-size}") final int bytesSize) {
-        byte[] randomBytes = new byte[bytesSize];
-        new SecureRandom().nextBytes(randomBytes);
-        this.token = Base64.getUrlEncoder().withoutPadding().encodeToString(randomBytes);
-        LOG.info("Telegram bot API token successfully generated");
+    public TelegramApiTokenServiceImpl(final TelegramBotProperties botProperties) {
+        this.botProperties = botProperties;
+        generateToken();
     }
 
     /**
@@ -60,6 +58,14 @@ public class TelegramApiTokenServiceImpl implements TelegramApiTokenService {
         byte[] candidateBytes = candidate.getBytes(StandardCharsets.UTF_8);
         byte[] tokenBytes = token.getBytes(StandardCharsets.UTF_8);
         return MessageDigest.isEqual(tokenBytes, candidateBytes);
+    }
+
+    private void generateToken() {
+        int bytesSize = botProperties.token().bytesSize();
+        byte[] randomBytes = new byte[bytesSize];
+        new SecureRandom().nextBytes(randomBytes);
+        this.token = Base64.getUrlEncoder().withoutPadding().encodeToString(randomBytes);
+        LOG.info("Telegram bot API token successfully generated");
     }
 
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -31,4 +31,4 @@ telegram:
     webhook:
       url: ${DEV_TELEGRAM_WEBHOOK_URL}
     init:
-      enabled: false
+      enabled: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,6 +25,10 @@ spring:
 
 telegram:
   bot:
+    allowed-update-types:
+      - message
+      - callback_query
+      - my_chat_member
     connections:
       value: 40
     webhook:

--- a/src/test/java/com/roman3455/deplifybot/ApplicationTest.java
+++ b/src/test/java/com/roman3455/deplifybot/ApplicationTest.java
@@ -1,7 +1,9 @@
 package com.roman3455.deplifybot;
 
 import com.roman3455.deplifybot.client.TelegramClient;
+import com.roman3455.deplifybot.configuration.TelegramBotProperties;
 import com.roman3455.deplifybot.configuration.TelegramFeignConfig;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -13,6 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @ActiveProfiles("test")
+@DisplayName("Application context bootstrapping")
 class ApplicationTest {
 
     @Autowired
@@ -24,25 +27,38 @@ class ApplicationTest {
     @Autowired
     private TelegramFeignConfig telegramFeignConfig;
 
+    @Autowired
+    private TelegramBotProperties telegramBotProperties;
+
     @Test
-    void contextLoads() {
+    @DisplayName("Should load application context")
+    void shouldLoadApplicationContext() {
         assertThat(applicationContext).isNotNull();
     }
 
     @Test
-    void  contextLoadsTelegramClient() {
+    @DisplayName("Should load TelegramClient bean")
+    void shouldLoadTelegramClientBean() {
         assertThat(telegramClient).isNotNull();
     }
 
     @Test
-    void  contextLoadsTelegramFeignConfig() {
+    @DisplayName("Should load TelegramFeignConfig bean")
+    void shouldLoadTelegramFeignConfigBean() {
         assertThat(telegramFeignConfig).isNotNull();
     }
 
     @Test
-    void contextLoadsJackson2ObjectMapperBuilderCustomizerBean() {
+    @DisplayName("Should load Jackson2ObjectMapperBuilder customizer bean")
+    void shouldLoadJackson2ObjectMapperBuilderCustomizerBean() {
         var customizers = applicationContext.getBeansOfType(Jackson2ObjectMapperBuilder.class);
         assertThat(customizers).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("Should load TelegramBotProperties bean")
+    void shouldLoadTelegramBotPropertiesBean() {
+        assertThat(telegramBotProperties).isNotNull();
     }
 
 }

--- a/src/test/java/com/roman3455/deplifybot/configuration/TelegramBotPropertiesValidationTest.java
+++ b/src/test/java/com/roman3455/deplifybot/configuration/TelegramBotPropertiesValidationTest.java
@@ -1,0 +1,123 @@
+package com.roman3455.deplifybot.configuration;
+
+import com.roman3455.deplifybot.util.ValidationTestSupport;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+@DisplayName("TelegramBotProperties - bean validation")
+public class TelegramBotPropertiesValidationTest extends ValidationTestSupport {
+
+    private static final int MAX_CONNECTIONS = 40;
+    private static final int BYTES_SIZE = 32;
+    private static List<String> allowedUpdateTypes;
+    private static TelegramBotProperties.Connections connections;
+    private static TelegramBotProperties.Webhook webhook;
+    private static TelegramBotProperties.Token token;
+
+    @BeforeAll
+    public static void setup() {
+        allowedUpdateTypes = List.of("message", "callback_query");
+        connections = new TelegramBotProperties.Connections(MAX_CONNECTIONS);
+        webhook = new TelegramBotProperties.Webhook("https://example.com", "/telegram/webhook");
+        token = new TelegramBotProperties.Token(BYTES_SIZE);
+    }
+
+    @Test
+    @DisplayName("Should pass validation for valid payload")
+    void shouldPassValidationPayload() {
+        var valid = new TelegramBotProperties(allowedUpdateTypes, connections, webhook, token);
+        assertValid(valid);
+    }
+
+    @Test
+    @DisplayName("Should fail validation when field 'allowedUpdateTypes' is empty (@NotEmpty)")
+    void shouldFailValidationAllowedUpdateTypesEmptyConstraint() {
+        final String field = "allowedUpdateTypes";
+        final String messageTemplate = "{jakarta.validation.constraints.NotEmpty.message}";
+        List<String> emptyAllowedUpdateTypes = List.of();
+        var invalid = new TelegramBotProperties(emptyAllowedUpdateTypes, connections, webhook, token);
+        assertViolationContains(invalid, field, messageTemplate);
+    }
+
+    @Test
+    @DisplayName("Should fail validation when element of 'allowedUpdateTypes' is blank (@NotBlank)")
+    void shouldFailValidationAllowedUpdateTypesElementBlank() {
+        final String field = "allowedUpdateTypes[0].<list element>";
+        final String messageTemplate = "{jakarta.validation.constraints.NotBlank.message}";
+        List<String> invalidAllowedUpdateTypes = List.of("  ");
+        var invalid = new TelegramBotProperties(invalidAllowedUpdateTypes, connections, webhook, token);
+        assertViolationContains(invalid, field, messageTemplate);
+    }
+
+    @Test
+    @DisplayName("Should fail validation when field 'connections' is null (@NotNull)")
+    void shouldFailValidationConnectionsNullConstraint() {
+        final String field = "connections";
+        final String messageTemplate = "{jakarta.validation.constraints.NotNull.message}";
+        var invalid = new TelegramBotProperties(allowedUpdateTypes, null, webhook, token);
+        assertViolationContains(invalid, field, messageTemplate);
+    }
+
+    @Test
+    @DisplayName("Should fail validation when field 'webhook' is null (@NotNull)")
+    void shouldFailValidationWebhookNullConstraint() {
+        final String field = "webhook";
+        final String messageTemplate = "{jakarta.validation.constraints.NotNull.message}";
+        var invalid = new TelegramBotProperties(allowedUpdateTypes, connections, null, token);
+        assertViolationContains(invalid, field, messageTemplate);
+    }
+
+    @Test
+    @DisplayName("Should fail validation when field 'token' is null (@NotNull)")
+    void shouldFailValidationTokenNullConstraint() {
+        final String field = "token";
+        final String messageTemplate = "{jakarta.validation.constraints.NotNull.message}";
+        var invalid = new TelegramBotProperties(allowedUpdateTypes, connections, webhook, null);
+        assertViolationContains(invalid, field, messageTemplate);
+    }
+
+    @Test
+    @DisplayName("Should fail validation when 'connections.value' is out of range (@Min/@Max)")
+    void shouldFailValidationConnectionsValueRange() {
+        final String field = "connections.value";
+        final String messageTemplate = "{jakarta.validation.constraints.Min.message}";
+        var invalidConnections = new TelegramBotProperties.Connections(0);
+        var invalid = new TelegramBotProperties(allowedUpdateTypes, invalidConnections, webhook, token);
+        assertViolationContains(invalid, field, messageTemplate);
+    }
+
+    @Test
+    @DisplayName("Should fail validation when 'webhook.url' is not HTTPS (@Pattern)")
+    void shouldFailValidationWebhookUrlPattern() {
+        final String field = "webhook.url";
+        final String messageTemplate = "{SetWebhookRequest.url.Pattern.message}";
+        var invalidWebhook = new TelegramBotProperties.Webhook("http://insecure.example.com", "/telegram/webhook");
+        var invalid = new TelegramBotProperties(allowedUpdateTypes, connections, invalidWebhook, token);
+        assertViolationContains(invalid, field, messageTemplate);
+    }
+
+    @Test
+    @DisplayName("Should fail validation when 'webhook.path' is blank (@NotBlank)")
+    void shouldFailValidationWebhookPathBlank() {
+        final String field = "webhook.path";
+        final String messageTemplate = "{jakarta.validation.constraints.NotBlank.message}";
+        var invalidWebhook = new TelegramBotProperties.Webhook("https://example.com", "   ");
+        var invalid = new TelegramBotProperties(allowedUpdateTypes, connections, invalidWebhook, token);
+        assertViolationContains(invalid, field, messageTemplate);
+    }
+
+    @Test
+    @DisplayName("Should fail validation when 'token.bytesSize' is below minimum (@Min)")
+    void shouldFailValidationTokenBytesSizeTooSmall() {
+        final int outOfBoundBytesSize = 8;
+        final String field = "token.bytesSize";
+        final String messageTemplate = "{jakarta.validation.constraints.Min.message}";
+        var invalidToken = new TelegramBotProperties.Token(outOfBoundBytesSize);
+        var invalid = new TelegramBotProperties(allowedUpdateTypes, connections, webhook, invalidToken);
+        assertViolationContains(invalid, field, messageTemplate);
+    }
+
+}

--- a/src/test/java/com/roman3455/deplifybot/dto/telegram/api/enums/BotCommandScopeTypeJsonTest.java
+++ b/src/test/java/com/roman3455/deplifybot/dto/telegram/api/enums/BotCommandScopeTypeJsonTest.java
@@ -8,9 +8,11 @@ import org.springframework.boot.test.autoconfigure.json.JsonTest;
 import org.springframework.boot.test.json.JacksonTester;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.test.context.ActiveProfiles;
 
 import static org.assertj.core.api.BDDAssertions.then;
 
+@ActiveProfiles("test")
 @JsonTest
 @Import(JacksonConfiguration.class)
 @DisplayName("BotCommandScopeType — JSON serialization & deserialization")

--- a/src/test/java/com/roman3455/deplifybot/dto/telegram/api/enums/ChatMemberStatusTypeJsonTest.java
+++ b/src/test/java/com/roman3455/deplifybot/dto/telegram/api/enums/ChatMemberStatusTypeJsonTest.java
@@ -8,9 +8,11 @@ import org.springframework.boot.test.autoconfigure.json.JsonTest;
 import org.springframework.boot.test.json.JacksonTester;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.test.context.ActiveProfiles;
 
 import static org.assertj.core.api.BDDAssertions.then;
 
+@ActiveProfiles("test")
 @JsonTest
 @Import(JacksonConfiguration.class)
 @DisplayName("ChatMemberStatusType — JSON serialization & deserialization")

--- a/src/test/java/com/roman3455/deplifybot/dto/telegram/api/enums/ChatTypeJsonTest.java
+++ b/src/test/java/com/roman3455/deplifybot/dto/telegram/api/enums/ChatTypeJsonTest.java
@@ -8,11 +8,13 @@ import org.springframework.boot.test.autoconfigure.json.JsonTest;
 import org.springframework.boot.test.json.JacksonTester;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.io.IOException;
 
 import static org.assertj.core.api.BDDAssertions.then;
 
+@ActiveProfiles("test")
 @JsonTest
 @Import(JacksonConfiguration.class)
 @DisplayName("ChatType — JSON serialization & deserialization")

--- a/src/test/java/com/roman3455/deplifybot/dto/telegram/api/enums/UpdateTypeJsonTest.java
+++ b/src/test/java/com/roman3455/deplifybot/dto/telegram/api/enums/UpdateTypeJsonTest.java
@@ -8,10 +8,12 @@ import org.springframework.boot.test.autoconfigure.json.JsonTest;
 import org.springframework.boot.test.json.JacksonTester;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.test.context.ActiveProfiles;
 
 import static org.assertj.core.api.BDDAssertions.then;
 
 
+@ActiveProfiles("test")
 @JsonTest
 @Import(JacksonConfiguration.class)
 @DisplayName("UpdateType — JSON serialization & deserialization")

--- a/src/test/java/com/roman3455/deplifybot/dto/telegram/api/request/BotCommandScopeJsonTest.java
+++ b/src/test/java/com/roman3455/deplifybot/dto/telegram/api/request/BotCommandScopeJsonTest.java
@@ -10,9 +10,11 @@ import org.springframework.boot.test.autoconfigure.json.JsonTest;
 import org.springframework.boot.test.json.JacksonTester;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.test.context.ActiveProfiles;
 
 import static org.assertj.core.api.BDDAssertions.then;
 
+@ActiveProfiles("test")
 @JsonTest
 @Import(JacksonConfiguration.class)
 @DisplayName("BotCommandScope — JSON serialization & deserialization")

--- a/src/test/java/com/roman3455/deplifybot/dto/telegram/api/request/BotDescriptionRequestJsonTest.java
+++ b/src/test/java/com/roman3455/deplifybot/dto/telegram/api/request/BotDescriptionRequestJsonTest.java
@@ -9,9 +9,11 @@ import org.springframework.boot.test.autoconfigure.json.JsonTest;
 import org.springframework.boot.test.json.JacksonTester;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.test.context.ActiveProfiles;
 
 import static org.assertj.core.api.BDDAssertions.then;
 
+@ActiveProfiles("test")
 @JsonTest
 @Import(JacksonConfiguration.class)
 @DisplayName("BotDescriptionRequest — JSON serialization & deserialization")

--- a/src/test/java/com/roman3455/deplifybot/dto/telegram/api/request/BotShortDescriptionRequestJsonTest.java
+++ b/src/test/java/com/roman3455/deplifybot/dto/telegram/api/request/BotShortDescriptionRequestJsonTest.java
@@ -9,9 +9,11 @@ import org.springframework.boot.test.autoconfigure.json.JsonTest;
 import org.springframework.boot.test.json.JacksonTester;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.test.context.ActiveProfiles;
 
 import static org.assertj.core.api.BDDAssertions.then;
 
+@ActiveProfiles("test")
 @JsonTest
 @Import(JacksonConfiguration.class)
 @DisplayName("BotShortDescriptionRequest — JSON serialization & deserialization")

--- a/src/test/java/com/roman3455/deplifybot/dto/telegram/api/request/MyCommandJsonTest.java
+++ b/src/test/java/com/roman3455/deplifybot/dto/telegram/api/request/MyCommandJsonTest.java
@@ -9,9 +9,11 @@ import org.springframework.boot.test.autoconfigure.json.JsonTest;
 import org.springframework.boot.test.json.JacksonTester;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.test.context.ActiveProfiles;
 
 import static org.assertj.core.api.BDDAssertions.then;
 
+@ActiveProfiles("test")
 @JsonTest
 @Import(JacksonConfiguration.class)
 @DisplayName("MyCommand — JSON serialization & deserialization")

--- a/src/test/java/com/roman3455/deplifybot/dto/telegram/api/request/SetMyCommandsRequestJsonTest.java
+++ b/src/test/java/com/roman3455/deplifybot/dto/telegram/api/request/SetMyCommandsRequestJsonTest.java
@@ -10,11 +10,13 @@ import org.springframework.boot.test.autoconfigure.json.JsonTest;
 import org.springframework.boot.test.json.JacksonTester;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 
 import static org.assertj.core.api.BDDAssertions.then;
 
+@ActiveProfiles("test")
 @JsonTest
 @Import(JacksonConfiguration.class)
 @DisplayName("SetMyCommandsRequest — JSON serialization & deserialization")

--- a/src/test/java/com/roman3455/deplifybot/dto/telegram/api/request/SetWebhookRequestJsonTest.java
+++ b/src/test/java/com/roman3455/deplifybot/dto/telegram/api/request/SetWebhookRequestJsonTest.java
@@ -10,11 +10,13 @@ import org.springframework.boot.test.autoconfigure.json.JsonTest;
 import org.springframework.boot.test.json.JacksonTester;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 
 import static org.assertj.core.api.BDDAssertions.then;
 
+@ActiveProfiles("test")
 @JsonTest
 @Import(JacksonConfiguration.class)
 @DisplayName("SetWebhookRequest — JSON serialization & deserialization")

--- a/src/test/java/com/roman3455/deplifybot/dto/telegram/api/response/CallbackQueryJsonTest.java
+++ b/src/test/java/com/roman3455/deplifybot/dto/telegram/api/response/CallbackQueryJsonTest.java
@@ -10,12 +10,14 @@ import org.springframework.boot.test.autoconfigure.json.JsonTest;
 import org.springframework.boot.test.json.JacksonTester;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.time.Instant;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.BDDAssertions.then;
 
+@ActiveProfiles("test")
 @JsonTest
 @Import(JacksonConfiguration.class)
 @DisplayName("CallbackQuery — JSON serialization & deserialization")

--- a/src/test/java/com/roman3455/deplifybot/dto/telegram/api/response/ChatJsonTest.java
+++ b/src/test/java/com/roman3455/deplifybot/dto/telegram/api/response/ChatJsonTest.java
@@ -10,9 +10,11 @@ import org.springframework.boot.test.autoconfigure.json.JsonTest;
 import org.springframework.boot.test.json.JacksonTester;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.test.context.ActiveProfiles;
 
 import static org.assertj.core.api.BDDAssertions.then;
 
+@ActiveProfiles("test")
 @JsonTest
 @Import(JacksonConfiguration.class)
 @DisplayName("Chat — JSON serialization & deserialization")

--- a/src/test/java/com/roman3455/deplifybot/dto/telegram/api/response/ChatMemberJsonTest.java
+++ b/src/test/java/com/roman3455/deplifybot/dto/telegram/api/response/ChatMemberJsonTest.java
@@ -10,9 +10,11 @@ import org.springframework.boot.test.autoconfigure.json.JsonTest;
 import org.springframework.boot.test.json.JacksonTester;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.test.context.ActiveProfiles;
 
 import static org.assertj.core.api.BDDAssertions.then;
 
+@ActiveProfiles("test")
 @JsonTest
 @Import(JacksonConfiguration.class)
 @DisplayName("ChatMember — JSON serialization & deserialization")

--- a/src/test/java/com/roman3455/deplifybot/dto/telegram/api/response/ChatMemberUpdatedJsonTest.java
+++ b/src/test/java/com/roman3455/deplifybot/dto/telegram/api/response/ChatMemberUpdatedJsonTest.java
@@ -11,11 +11,13 @@ import org.springframework.boot.test.autoconfigure.json.JsonTest;
 import org.springframework.boot.test.json.JacksonTester;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.time.Instant;
 
 import static org.assertj.core.api.BDDAssertions.then;
 
+@ActiveProfiles("test")
 @JsonTest
 @Import(JacksonConfiguration.class)
 @DisplayName("ChatMemberUpdated — JSON serialization & deserialization")

--- a/src/test/java/com/roman3455/deplifybot/dto/telegram/api/response/ChatSharedJsonTest.java
+++ b/src/test/java/com/roman3455/deplifybot/dto/telegram/api/response/ChatSharedJsonTest.java
@@ -9,9 +9,11 @@ import org.springframework.boot.test.autoconfigure.json.JsonTest;
 import org.springframework.boot.test.json.JacksonTester;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.test.context.ActiveProfiles;
 
 import static org.assertj.core.api.BDDAssertions.then;
 
+@ActiveProfiles("test")
 @JsonTest
 @Import(JacksonConfiguration.class)
 @DisplayName("ChatShared — JSON serialization & deserialization")

--- a/src/test/java/com/roman3455/deplifybot/dto/telegram/api/response/MessageJsonTest.java
+++ b/src/test/java/com/roman3455/deplifybot/dto/telegram/api/response/MessageJsonTest.java
@@ -10,12 +10,14 @@ import org.springframework.boot.test.autoconfigure.json.JsonTest;
 import org.springframework.boot.test.json.JacksonTester;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.time.Instant;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.BDDAssertions.then;
 
+@ActiveProfiles("test")
 @JsonTest
 @Import(JacksonConfiguration.class)
 @DisplayName("Message — JSON serialization & deserialization")

--- a/src/test/java/com/roman3455/deplifybot/dto/telegram/api/response/ResponseBodyJsonTest.java
+++ b/src/test/java/com/roman3455/deplifybot/dto/telegram/api/response/ResponseBodyJsonTest.java
@@ -9,12 +9,14 @@ import org.springframework.boot.test.autoconfigure.json.JsonTest;
 import org.springframework.boot.test.json.JacksonTester;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.BDDAssertions.then;
 
+@ActiveProfiles("test")
 @JsonTest
 @Import(JacksonConfiguration.class)
 @DisplayName("ResponseBody — JSON serialization & deserialization")

--- a/src/test/java/com/roman3455/deplifybot/dto/telegram/api/response/UpdateJsonTest.java
+++ b/src/test/java/com/roman3455/deplifybot/dto/telegram/api/response/UpdateJsonTest.java
@@ -11,12 +11,14 @@ import org.springframework.boot.test.autoconfigure.json.JsonTest;
 import org.springframework.boot.test.json.JacksonTester;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.time.Instant;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.BDDAssertions.then;
 
+@ActiveProfiles("test")
 @JsonTest
 @Import(JacksonConfiguration.class)
 @DisplayName("Update — JSON serialization & deserialization")

--- a/src/test/java/com/roman3455/deplifybot/dto/telegram/api/response/UserJsonTest.java
+++ b/src/test/java/com/roman3455/deplifybot/dto/telegram/api/response/UserJsonTest.java
@@ -9,9 +9,11 @@ import org.springframework.boot.test.autoconfigure.json.JsonTest;
 import org.springframework.boot.test.json.JacksonTester;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.test.context.ActiveProfiles;
 
 import static org.assertj.core.api.BDDAssertions.then;
 
+@ActiveProfiles("test")
 @JsonTest
 @Import(JacksonConfiguration.class)
 @DisplayName("User — JSON serialization & deserialization")

--- a/src/test/java/com/roman3455/deplifybot/service/telegram/TelegramApiTokenServiceTest.java
+++ b/src/test/java/com/roman3455/deplifybot/service/telegram/TelegramApiTokenServiceTest.java
@@ -1,21 +1,35 @@
 package com.roman3455.deplifybot.service.telegram;
 
+import com.roman3455.deplifybot.configuration.TelegramBotProperties;
 import com.roman3455.deplifybot.service.telegram.impl.TelegramApiTokenServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest(classes = {TelegramApiTokenServiceTest.class})
-@Import(TelegramApiTokenServiceImpl.class)
 @DisplayName("TelegramApiTokenService — Token format & behavior test")
 class TelegramApiTokenServiceTest {
 
-    @Autowired
     private TelegramApiTokenService service;
+
+    @BeforeEach
+    void setUp() {
+        final int bytesSize = 32;
+        final int maxConnections = 40;
+        TelegramBotProperties properties = new TelegramBotProperties(
+                List.of("message"),
+                new TelegramBotProperties.Connections(maxConnections),
+                new TelegramBotProperties.Webhook(
+                        "https://example.com/webhook",
+                        "/telegram/webhook"
+                ),
+                new TelegramBotProperties.Token(bytesSize)
+        );
+        service = new TelegramApiTokenServiceImpl(properties);
+    }
 
     @Test
     @DisplayName("Should return URL-safe Base64 token without '=' and remain stable through bean lifecycle")


### PR DESCRIPTION
- ApplicationTest:
  - add BDD @DisplayName & method name for all tests
  - add TelegramBotProperties test
- *JsonTest:
  - add @ActiveProfiles("test")
- TelegramBotProperties:
  - Application @EnableConfigProperties
  - application.yml add allowed upd types
  - application-dev.yml init.enabled true
  - add validation tests
- Replace @Value configs with BotProperties:
  - BotInitializer
  - TelegramApiTokenServiceImpl
  - TelegramApiTokenServiceTest

Closes: issue-0033