### PR TITLE
feat (validation): implement BytesLength Annotation and fix ISO6391 message

### DIFF
--- a/src/main/java/com/roman3455/deplifybot/util/validator/bytes_length/BytesLength.java
+++ b/src/main/java/com/roman3455/deplifybot/util/validator/bytes_length/BytesLength.java
@@ -1,0 +1,54 @@
+package com.roman3455.deplifybot.util.validator.bytes_length;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Custom annotation to validate the byte length of a string.
+ *
+ * <p>Ensures that the string's byte length is within the specified range. Can be applied to fields or parameters.
+ * The validation is performed based on the specified charset (default is UTF-8).</p>
+ */
+@Documented
+@Constraint(validatedBy = BytesLengthValidator.class)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface BytesLength {
+
+    /**
+     * Error message to be used when validation fails.
+     */
+    String message() default "{BytesLength.validation.constraints.message}";
+
+    /**
+     * Groups for the constraint (used for grouping constraints in validation).
+     */
+    Class<?>[] groups() default {};
+
+    /**
+     * Payload for the constraint (can be used to carry additional data).
+     */
+    Class<? extends Payload>[] payload() default {};
+
+    /**
+     * Minimum byte length (inclusive).
+     */
+    int min() default 0;
+
+    /**
+     * Maximum byte length (inclusive).
+     */
+    int max() default Integer.MAX_VALUE;
+
+    /**
+     * Charset used for calculating the byte length (default is UTF-8).
+     */
+    String charset() default "UTF-8";
+
+}

--- a/src/main/java/com/roman3455/deplifybot/util/validator/bytes_length/BytesLengthValidator.java
+++ b/src/main/java/com/roman3455/deplifybot/util/validator/bytes_length/BytesLengthValidator.java
@@ -1,0 +1,56 @@
+package com.roman3455.deplifybot.util.validator.bytes_length;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.nio.charset.Charset;
+
+/**
+ * Validator implementation for the {@link BytesLength} annotation.
+ *
+ * <p>Ensures that the length of the string, in bytes, is within the specified range. The validator uses the specified
+ * charset to calculate the byte length, which may differ from the character length (especially for multibyte
+ * characters in encodings like UTF-8).</p>
+ */
+public class BytesLengthValidator implements ConstraintValidator<BytesLength, String> {
+
+    private int min;
+    private int max;
+    private Charset charset;
+
+    /**
+     * Initializes the validator with the constraint annotation.
+     *
+     * <p>This method extracts the configuration parameters (min, max, charset) from the annotation
+     * and prepares the validator for the validation process.</p>
+     *
+     * @param constraintAnnotation The annotation instance that holds the configuration values for validation.
+     */
+    @Override
+    public void initialize(final BytesLength constraintAnnotation) {
+        this.min = constraintAnnotation.min();
+        this.max = constraintAnnotation.max();
+        this.charset = Charset.forName(constraintAnnotation.charset());
+    }
+
+    /**
+     * Validates the byte length of the given string.
+     *
+     * <p>This method checks whether the byte length of the provided string falls within the specified
+     * range defined by the min and max parameters of the annotation.
+     * The length is calculated using the specified charset (default is UTF-8).</p>
+     *
+     * @param value The string to validate.
+     * @param context Contextual data and state about the validation process.
+     * @return {@code true} if the string's byte length is within the valid range, otherwise {@code false}.
+     */
+    @Override
+    public boolean isValid(final String value, final ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
+        int bytesLength = value.getBytes(charset).length;
+        return bytesLength >= min && bytesLength <= max;
+    }
+
+}

--- a/src/main/java/com/roman3455/deplifybot/util/validator/iso6391/ISO6391.java
+++ b/src/main/java/com/roman3455/deplifybot/util/validator/iso6391/ISO6391.java
@@ -29,7 +29,7 @@ public @interface ISO6391 {
      *
      * @return the error message template.
      */
-    String message() default "Invalid ISO 639-1 language code";
+    String message() default "{ISO6391.validation.constraints.message}";
 
     /**
      * Allows specification of validation groups, to which this constraint belongs.

--- a/src/main/resources/i18n/ValidationMessages.properties
+++ b/src/main/resources/i18n/ValidationMessages.properties
@@ -4,15 +4,17 @@ jakarta.validation.constraints.NotBlank.message=must not be blank
 jakarta.validation.constraints.NotEmpty.message=must not be empty
 jakarta.validation.constraints.Positive.message=must be greater than 0
 jakarta.validation.constraints.Size.message=size must be between {min} and {max} characters
+
 # === Common override message patterns ===
 Size.min.message=size must be at least {min} characters
 Size.max.message=size must be at most {max} characters
+
 # === Custom message patterns ===
-ISO6391.languageCode.message=allowed ISO 639-1 code length must be exactly 2 characters
 MyCommand.command.Pattern.message=only lowercase letters 'a–z', digits '0–9', and underscores '_' are allowed
 SetWebhookRequest.url.Pattern.message=URL must start with 'https://'
 SetWebhookRequest.secretToken.Pattern.message=only letters 'A–Z', 'a–z', digits '0–9', underscores '_', and hyphens \
   '-' are allowed
+
     # === AssertTrue ===
 BotCommandScope.isChatIdConsistentWithType.AssertTrue='chatId' must be provided if 'type' is 'CHAT', and must be null \
   otherwise
@@ -21,3 +23,7 @@ BotDescriptionRequest.isAnyProvided.AssertTrue=at least one of the fields 'descr
 BotShortDescriptionRequest.isAnyProvided.AssertTrue=at least one of the fields 'shortDescription' or 'languageCode' \
   must be provided
 Update.isAnyProvided.AssertTrue=at most one of the fields 'message', 'callbackQuery' or 'myChatMember' must be provided
+
+    # === Validator ===
+BytesLength.validation.constraints.message=length must be between {min} and {max} bytes
+ISO6391.validation.constraints.message==allowed only ISO 639-1 language code with 2 chars length

--- a/src/main/resources/i18n/ValidationMessages_en.properties
+++ b/src/main/resources/i18n/ValidationMessages_en.properties
@@ -4,15 +4,17 @@ jakarta.validation.constraints.NotBlank.message=must not be blank
 jakarta.validation.constraints.NotEmpty.message=must not be empty
 jakarta.validation.constraints.Positive.message=must be greater than 0
 jakarta.validation.constraints.Size.message=size must be between {min} and {max} characters
+
 # === Common override message patterns ===
 Size.min.message=size must be at least {min} characters
 Size.max.message=size must be at most {max} characters
+
 # === Custom message patterns ===
-ISO6391.languageCode.message=allowed ISO 639-1 code length must be exactly 2 characters
 MyCommand.command.Pattern.message=only lowercase letters 'a–z', digits '0–9', and underscores '_' are allowed
 SetWebhookRequest.url.Pattern.message=URL must start with 'https://'
 SetWebhookRequest.secretToken.Pattern.message=only letters 'A–Z', 'a–z', digits '0–9', underscores '_', and hyphens \
   '-' are allowed
+
     # === AssertTrue ===
 BotCommandScope.isChatIdConsistentWithType.AssertTrue='chatId' must be provided if 'type' is 'CHAT', and must be null \
   otherwise
@@ -21,3 +23,7 @@ BotDescriptionRequest.isAnyProvided.AssertTrue=at least one of the fields 'descr
 BotShortDescriptionRequest.isAnyProvided.AssertTrue=at least one of the fields 'shortDescription' or 'languageCode' \
   must be provided
 Update.isAnyProvided.AssertTrue=at most one of the fields 'message', 'callbackQuery' or 'myChatMember' must be provided
+
+# === Validator ===
+BytesLength.validation.constraints.message=length must be between {min} and {max} bytes
+ISO6391.validation.constraints.message==allowed only ISO 639-1 language code with 2 chars length

--- a/src/main/resources/i18n/ValidationMessages_ru.properties
+++ b/src/main/resources/i18n/ValidationMessages_ru.properties
@@ -4,15 +4,17 @@ jakarta.validation.constraints.NotBlank.message=не должно быть пу�
 jakarta.validation.constraints.NotEmpty.message=не должно быть пустым
 jakarta.validation.constraints.Positive.message=должно быть больше 0
 jakarta.validation.constraints.Size.message=длина должна быть в пределах от {min} до {max} символов
+
 # === Common override message patterns ===
 Size.min.message=длина должна быть не менее {min} символов
 Size.max.message=длина должна быть не более {max} символов
+
 # === Custom message patterns ===
-ISO6391.languageCode.message=допустимая длина кода ISO 639-1 должна составлять ровно 2 символа
 MyCommand.command.Pattern.message=допустимы только строчные буквы 'a–z', цифры '0–9' и символ подчёркивания '_'
 SetWebhookRequest.url.Pattern.message=URL должен начинаться с 'https://'
 SetWebhookRequest.secretToken.Pattern.message=допустимы только буквы 'A–Z', 'a–z', цифры '0–9', символ подчёркивания \
   '_' и дефис '-'
+
     # === AssertTrue ===
 BotCommandScope.isChatIdConsistentWithType.AssertTrue='chatId' должно быть указано, если 'type' имеет значение 'CHAT'\
   , и быть пустым в остальных случаях
@@ -21,3 +23,7 @@ BotDescriptionRequest.isAnyProvided.AssertTrue=должно быть указа�
 BotShortDescriptionRequest.isAnyProvided.AssertTrue=должно быть указано хотя бы одно из полей: 'shortDescription' или \
   'languageCode'
 Update.isAnyProvided.AssertTrue=должно быть не более одного поля 'message', 'callbackQuery' или 'myChatMember'
+
+# === Validator ===
+BytesLength.validation.constraints.message=длина должна быть в пределах от {min} до {max} байтов
+ISO6391.validation.constraints.message=допустим только ISO 639-1 языковой код длиной 2 символа

--- a/src/test/java/com/roman3455/deplifybot/util/validator/bytes_length/BytesLengthValidatorTest.java
+++ b/src/test/java/com/roman3455/deplifybot/util/validator/bytes_length/BytesLengthValidatorTest.java
@@ -1,0 +1,69 @@
+package com.roman3455.deplifybot.util.validator.bytes_length;
+
+import com.roman3455.deplifybot.util.ValidationTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Bean Validation of BytesLengthValidator")
+class BytesLengthValidatorTest extends ValidationTestSupport {
+
+    private static final String FIELD = "text";
+    private static final String MESSAGE_PART = "{BytesLength.validation.constraints.message}";
+    private static final int ALLOWED_MIN_LENGTH = 2;
+    private static final int ALLOWED_MAX_LENGTH = 4;
+
+    private record DefaultTestDto(
+            @BytesLength
+            String text
+    ) {
+    }
+
+    private record TestDto(
+            @BytesLength(min = ALLOWED_MIN_LENGTH, max = ALLOWED_MAX_LENGTH)
+            String text
+    ) {
+    }
+
+    @Test
+    @DisplayName("Should allow null string value")
+    void shouldAllowNullString() {
+        var valid = new DefaultTestDto(null);
+        assertValid(valid);
+    }
+
+    @Test
+    @DisplayName("Should allow empty string value")
+    void shouldAllowEmptyString() {
+        var valid = new DefaultTestDto("");
+        assertValid(valid);
+    }
+
+    @Test
+    @DisplayName("Should accept bytes length equals allowed min value")
+    void shouldAcceptMinValue() {
+        var valid = new TestDto("x".repeat(ALLOWED_MIN_LENGTH));
+        assertValid(valid);
+    }
+
+    @Test
+    @DisplayName("Should accept bytes length equals allowed max value")
+    void shouldAcceptMaxValue() {
+        var valid = new TestDto("x".repeat(ALLOWED_MAX_LENGTH));
+        assertValid(valid);
+    }
+
+    @Test
+    @DisplayName("Should reject bytes length below allowed min value")
+    void shouldRejectValueBelowMin() {
+        var invalid = new TestDto("x".repeat(ALLOWED_MIN_LENGTH - 1));
+        assertViolationContains(invalid, FIELD, MESSAGE_PART);
+    }
+
+    @Test
+    @DisplayName("Should reject bytes length above allowed max value")
+    void shouldRejectValueAboveMax() {
+        var invalid = new TestDto("x".repeat(ALLOWED_MAX_LENGTH + 1));
+        assertViolationContains(invalid, FIELD, MESSAGE_PART);
+    }
+
+}

--- a/src/test/java/com/roman3455/deplifybot/util/validator/iso6391/ISO6391ValidatorTest.java
+++ b/src/test/java/com/roman3455/deplifybot/util/validator/iso6391/ISO6391ValidatorTest.java
@@ -33,7 +33,7 @@ class ISO6391ValidatorTest extends ValidationTestSupport {
     @DisplayName("Should reject invalid language codes")
     void shouldRejectInvalidLanguageCodes() {
         final String field = "languageCode";
-        final String messagePart = "Invalid ISO 639-1 language code";
+        final String messagePart = "{ISO6391.validation.constraints.message}";
         assertViolationContains(new TestDto("x"), field, messagePart);
         assertViolationContains(new TestDto("eng"), field, messagePart);
         assertViolationContains(new TestDto("zz"), field, messagePart);


### PR DESCRIPTION
- ValidationMessages*.properties:
 - add BytesLength & ISO6391 constraint messages
- ISO6391 & ISO6931ValidatorTest:
 - add localized message
- BytesLength*:
 - create & test validation interface

Closes: issue-0037